### PR TITLE
parameterizing the graph sync run schedule

### DIFF
--- a/graph_snyk_cve_sync.py
+++ b/graph_snyk_cve_sync.py
@@ -120,6 +120,10 @@ class Helper:
         """Return if the delta feed mode is on."""
         return os.environ.get('SNYK_DELTA_FEED_MODE', 'false').lower() in ('1', 'yes', 'true')
 
+    def ingestion_run_time(self):
+        """Return the time when ingestion needs to run."""
+        return os.environ.get('SNYK_INGESTION_RUN_TIME', '18')
+
 
 class SnykCveSync:
     """Snyk class to sync cves to graph."""
@@ -454,7 +458,7 @@ class SnykCveSync:
         force = self.helper.force_run_ingestion()
         if force:
             return False
-        return date.strftime('%H') != '06'
+        return date.strftime('%H') != self.helper.ingestion_run_time()
 
     def _generate_snyk_report(self):
         """Generate the ingestion report for snyk."""

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -40,6 +40,8 @@ objects:
                   value: "${SNYK_URL}"
                 - name: SNYK_INGESTION_FORCE_RUN
                   value: "${SNYK_INGESTION_FORCE_RUN}"
+                - name: SNYK_INGESTION_RUN_TIME
+                  value: "${SNYK_INGESTION_RUN_TIME}"
                 - name: SNYK_FEED_SAVE_DAYS
                   value: "${SNYK_FEED_SAVE_DAYS}"
                 - name: SELECTIVE_ECOSYSTEM_SNYK_SYNC
@@ -118,6 +120,12 @@ parameters:
   required: true
   name: SNYK_DELTA_FEED_MODE
   value: "true"
+
+- description: Either to run at 00 06 12 or 18 hours
+  displayName: Snyk ingestion run time
+  required: true
+  name: SNYK_INGESTION_RUN_TIME
+  value: "18"
 
 - description: Forcefully start a snyk ingestion at any time of the day
   displayName: Snyk ingestion mode

--- a/snyk_feed.py
+++ b/snyk_feed.py
@@ -103,7 +103,7 @@ class SnykDataFetcher:
         force = self.helper.force_run_ingestion()
         if force:
             return False
-        return date.strftime('%H') != '18'
+        return date.strftime('%H') != self.helper.ingestion_run_time()
 
     def run_snyk_fetch(self):
         """Entry function for the snyk fetch feed.

--- a/tests/test_graph_snyk_cve_sync.py
+++ b/tests/test_graph_snyk_cve_sync.py
@@ -573,9 +573,10 @@ def test_run_snyk_sync(m1, m2, m3, m4, m5, m6, m7):
     assert val is None
 
 
+@patch.dict(os.environ, {'SNYK_INGESTION_RUN_TIME': '18'})
 def test_disable_snyk_run():
     """Test disable_snyk_run."""
-    val = scs.disable_snyk_run(datetime(2020, 2, 27, 6, 1))
+    val = scs.disable_snyk_run(datetime(2020, 2, 27, 18, 1))
     assert val is False
 
     val = scs.disable_snyk_run(datetime(2020, 2, 27, 12, 1))

--- a/tests/test_snyk_feed.py
+++ b/tests/test_snyk_feed.py
@@ -1,6 +1,7 @@
 """Test snyk_feed.py script."""
 
 import pytest
+import os
 from unittest.mock import patch
 from datetime import datetime
 
@@ -13,6 +14,7 @@ class S3Obj:
     text = "{\"a\": \"b\"}"
 
 
+@patch.dict(os.environ, {'SNYK_INGESTION_RUN_TIME': '18'})
 def test_disable_snyk_run():
     """Test disable_snyk_run."""
     val = sdf._disable_snyk_run(datetime(2020, 4, 4, 18, 1))


### PR DESCRIPTION
this was a pending thing for a long time. Removing the hardcoded values for run schedule for graph cve sync