### PR TITLE
golang support added

### DIFF
--- a/data/default_report.json
+++ b/data/default_report.json
@@ -45,7 +45,6 @@
       "deletion_accuracy": "",
       "packages_affected": 0,
       "versions_affected": 0,
-      "commit_hash_affected": 0,
       "premium_count": 0,
       "pvt_pkg_vulnerability_count": 0
     }

--- a/data/default_report.json
+++ b/data/default_report.json
@@ -1,0 +1,75 @@
+{
+  "stats": {
+    "maven": {
+      "successfully_ingested": 0,
+      "to_be_ingested": 0,
+      "ingestion_accuracy": "",
+      "successfully_deleted": 0,
+      "to_be_deleted": 0,
+      "deletion_accuracy": "",
+      "packages_affected": 0,
+      "versions_affected": 0,
+      "premium_count": 0,
+      "pvt_pkg_vulnerability_count": 0
+    },
+    "pypi": {
+      "successfully_ingested": 0,
+      "to_be_ingested": 0,
+      "ingestion_accuracy": "",
+      "successfully_deleted": 0,
+      "to_be_deleted": 0,
+      "deletion_accuracy": "",
+      "packages_affected": 0,
+      "versions_affected": 0,
+      "premium_count": 0,
+      "pvt_pkg_vulnerability_count": 0
+    },
+    "npm": {
+      "successfully_ingested": 0,
+      "to_be_ingested": 0,
+      "ingestion_accuracy": "",
+      "successfully_deleted": 0,
+      "to_be_deleted": 0,
+      "deletion_accuracy": "",
+      "packages_affected": 0,
+      "versions_affected": 0,
+      "premium_count": 0,
+      "pvt_pkg_vulnerability_count": 0
+    },
+    "golang": {
+      "successfully_ingested": 0,
+      "to_be_ingested": 0,
+      "ingestion_accuracy": "",
+      "successfully_deleted": 0,
+      "to_be_deleted": 0,
+      "deletion_accuracy": "",
+      "packages_affected": 0,
+      "versions_affected": 0,
+      "commit_hash_affected": 0,
+      "premium_count": 0,
+      "pvt_pkg_vulnerability_count": 0
+    }
+  },
+  "details": {
+    "maven": {
+      "ingest": {},
+      "delete": {},
+      "pvt_pkgs": {}
+    },
+    "pypi": {
+      "ingest": {},
+      "delete": {},
+      "pvt_pkgs": {}
+    },
+    "npm": {
+      "ingest": {},
+      "delete": {},
+      "pvt_pkgs": {}
+    },
+    "golang": {
+      "ingest": {},
+      "delete": {},
+      "pvt_pkgs": {}
+    }
+  }
+}

--- a/data/feed_sample.json
+++ b/data/feed_sample.json
@@ -1,0 +1,3188 @@
+{
+  "golang": [
+
+    {
+      "creationTime": "2018-11-25T13:53:03.621698Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [
+        "CVE-2018-18926"
+      ],
+      "cvssScore": 8.1,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\n[go-gitea/gitea](https://github.com/go-gitea/gitea) is a self-hosted git service.\r\n\r\nAffected versions of this package are vulnerable to  Remote Code Execution due to not properly validating session IDs. This is related to session ID handling in the go-macaron/session code for Macaron.\r\n\r\n## Remediation\r\nUpgrade `go-gitea/gitea' to version 1.5.2 or higher.\n\n## References\n- [GitHub Issue](https://github.com/go-gitea/gitea/issues/5140)\n- [GitHub PR](https://github.com/go-gitea/gitea/pull/5177)\n- [Github Commit](https://github.com/go-gitea/gitea/commit/aeb5655c25053bdcd7eee94ea37df88468374162)\n",
+      "disclosureTime": "2018-11-04T06:43:48Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "hashesRange": [
+        "<aeb5655c25053bdcd7eee94ea37df88468374162"
+      ],
+      "id": "SNYK-GOLANG-GITHUBCOMGOGITEAGITEA-72635",
+      "language": "golang",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-28T16:15:53.980730Z",
+      "package": "github.com/go-gitea/gitea",
+      "patchExists": false,
+      "publicationTime": "2018-11-28T16:15:53.944206Z",
+      "references": [
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/go-gitea/gitea/issues/5140"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/go-gitea/gitea/pull/5177"
+        },
+        {
+          "title": "Github Commit",
+          "url": "https://github.com/go-gitea/gitea/commit/aeb5655c25053bdcd7eee94ea37df88468374162"
+        }
+      ],
+      "registry": null,
+      "severity": "high",
+      "title": "Remote Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMGOGITEAGITEA-72635",
+      "vulnerableHashes": [
+        "cc3cbf8cbee4b28902abc7fccee60499bd4c1246",
+        "685631627e5c4db881160bfc9b39dc45143989f6"
+      ],
+      "vulnerableVersions": [
+        "<1.5.2"
+      ]
+    },
+    {
+      "creationTime": "2018-11-25T12:04:37.099793Z",
+      "credit": [
+        "unknown"
+      ],
+      "cves": [],
+      "cvssScore": 6.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N",
+      "cwes": [
+        "CWE-79"
+      ],
+      "description": "## Overview\n[grafana](https://github.com/grafana/grafana)  is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.\r\n\r\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) attacks via the query editor.\r\n\r\n## Details\r\nCross-Site Scripting (XSS) attacks occur when an attacker tricks a user’s browser to execute malicious JavaScript code in the context of a victim’s domain. Such scripts can steal the user’s session cookies for the domain, scrape or modify its content, and perform or modify actions on the user’s behalf, actions typically blocked by the browser’s Same Origin Policy.\r\n\r\nThese attacks are possible by escaping the context of the web application and injecting malicious scripts in an otherwise trusted website. These scripts can introduce additional attributes (say, a \"new\" option in a dropdown list or a new link to a malicious site) and can potentially execute code on the clients side, unbeknown to the victim. This occurs when characters like `<` `>` `\"` `'` are not escaped properly.\r\n\r\nThere are a few types of XSS:\r\n- **Persistent XSS** is an attack in which the malicious code persists into the web app’s database.\r\n- **Reflected XSS** is an which the website echoes back a portion of the request. The attacker needs to trick the user into clicking a malicious link (for instance through a phishing email or malicious JS on another page), which triggers the XSS attack.\r\n- **DOM-based XSS** is an that occurs purely in the browser when client-side JavaScript echoes back a portion of the URL onto the page. DOM-Based XSS is notoriously hard to detect, as the server never gets a chance to see the attack taking place.\r\n\r\n## Remediation\r\nUpgrade `grafana` to version 5.3.2 or higher.\n\n## References\n- [GitHub Commit](https://github.com/grafana/grafana/commit/5bd11744dd889565719e34fd6383d9189cc80f12)\n- [GitHub Issue](https://github.com/grafana/grafana/issues/13667)\n- [GitHub PR](https://github.com/grafana/grafana/pull/13670)\n",
+      "disclosureTime": "2018-10-14T11:47:29Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "hashesRange": [],
+      "id": "SNYK-GOLANG-GITHUBCOMGRAFANAGRAFANA-72632",
+      "language": "golang",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-28T16:15:54.070081Z",
+      "package": "github.com/grafana/grafana",
+      "patchExists": false,
+      "publicationTime": "2018-11-28T16:15:54.049112Z",
+      "references": [
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/grafana/grafana/issues/13667"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/grafana/grafana/pull/13670"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/grafana/grafana/commit/5bd11744dd889565719e34fd6383d9189cc80f12"
+        }
+      ],
+      "registry": null,
+      "severity": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "url": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMGRAFANAGRAFANA-72632",
+      "vulnerableHashes": [],
+      "vulnerableVersions": [
+        "<5.3.2"
+      ]
+    },
+    {
+      "creationTime": "2019-01-03T15:02:51.232967Z",
+      "credit": [
+        "andyzhangx"
+      ],
+      "cves": [
+        "CVE-2018-1002101"
+      ],
+      "cvssScore": 7.1,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:L",
+      "cwes": [
+        "CWE-78"
+      ],
+      "description": "## Overview\r\n\r\n[github.com/kubernetes/kubernetes/pkg/util/mount](https://github.com/kubernetes/kubernetes) is a Production-Grade Container Scheduling and Management.\r\n\r\n\r\nAffected versions of this package are vulnerable to Arbitrary Command Injection.\r\nUser input was handled insecurely while setting up volume mounts on Windows nodes, which could lead to command line argument injection.\r\n\r\n## Remediation\r\n\r\nUpgrade `github.com/kubernetes/kubernetes/pkg/util/mount` to version 1.9.10, 1.10.6, 1.11.2 or higher.\r\n\r\n\r\n## References\r\n\r\n- [GitHub Commit](https://github.com/kubernetes/kubernetes/commit/d65039c56ce4de5f2efdc38aa1284eeb95f89169)\r\n\r\n- [GitHub PR](https://github.com/kubernetes/kubernetes/pull/65751)\r\n\r\n- [GitHub Issue](https://github.com/kubernetes/kubernetes/issues/65750)\r\n",
+      "disclosureTime": "2018-07-03T15:01:26Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "hashesRange": [
+        "< d65039c56ce4de5f2efdc38aa1284eeb95f89169"
+      ],
+      "id": "SNYK-GOLANG-GITHUBCOMKUBERNETESKUBERNETESPKGUTILMOUNT-72885",
+      "language": "golang",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-01-03T17:01:51.630809Z",
+      "package": "github.com/kubernetes/kubernetes/pkg/util/mount",
+      "patchExists": false,
+      "publicationTime": "2019-01-03T17:01:51.612869Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/kubernetes/kubernetes/commit/d65039c56ce4de5f2efdc38aa1284eeb95f89169"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/kubernetes/kubernetes/pull/65751"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/kubernetes/kubernetes/issues/65750"
+        }
+      ],
+      "registry": null,
+      "severity": "high",
+      "title": "Arbitrary Command Injection",
+      "url": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMKUBERNETESKUBERNETESPKGUTILMOUNT-72885",
+      "vulnerableHashes": [
+        "0be97c88708785a3102b06f803e34bed4752f69c",
+        "6b8ccc7d5c5ff9d1635966ddac45b6539c6650b4",
+        "9ed12a413d104f262aa64c3853ca246322c60e86",
+        "700325b37b3a54e81d941c6ad5d8c6af049456ef"
+      ],
+      "vulnerableVersions": [
+        ">=1.9.0 <1.9.10",
+        ">=1.10.0 <1.10.6",
+        ">=1.11.0 <1.11.2"
+      ]
+    }
+  ],
+  "java": [
+    {
+      "creationTime": "2018-06-06T09:42:14.837000Z",
+      "credit": [
+        "Caio Vargas",
+        "Matheus Bernardes",
+        "Nubank"
+      ],
+      "cves": [
+        "CVE-2018-10054"
+      ],
+      "cvssScore": 8.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\n[Datomic](https://www.datomic.com/) is a transactional database with a flexible data model, elastic scaling, and rich queries\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution. An unauthorized malicious user may be able to send a specially crafted `H2 SQL ALIAS` command which will execute arbitrary Java code.\n\n## Remediation\nUpgrade Datomic to version `0.9.5697` or higher.\n\n## References\n- [Matheus Bernardes' Blog](https://mthbernardes.github.io/rce/2018/03/14/abusing-h2-database-alias.html)\n- [Datomic Blog](http://blog.datomic.com/2018/03/important-security-update.html)\n- [Datomic Security Advisory](https://forum.datomic.com/t/important-security-update-0-9-5697/379)\n- [Exploit DB](https://www.exploit-db.com/exploits/44422/)\n",
+      "disclosureTime": "2018-04-12T09:42:14.837000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-COMDATOMIC-32349",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-02-06T08:03:07.687557Z",
+      "package": "com.datomic:datomic-free",
+      "patchExists": false,
+      "publicationTime": "2018-06-06T15:07:50.413000Z",
+      "references": [
+        {
+          "title": "Matheus Bernardes' Blog",
+          "url": "https://mthbernardes.github.io/rce/2018/03/14/abusing-h2-database-alias.html"
+        },
+        {
+          "title": "Datomic Blog",
+          "url": "http://blog.datomic.com/2018/03/important-security-update.html"
+        },
+        {
+          "title": "Datomic Security Advisory",
+          "url": "https://forum.datomic.com/t/important-security-update-0-9-5697/379"
+        },
+        {
+          "title": "Exploit DB",
+          "url": "https://www.exploit-db.com/exploits/44422/"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "high",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-COMDATOMIC-32349",
+      "vulnerableVersions": [
+        "[,0.9.5697)"
+      ]
+    },
+    {
+      "creationTime": "2017-09-14T14:43:48.569000Z",
+      "credit": [
+        "Liao Xinxi"
+      ],
+      "cves": [
+        "CVE-2017-7525"
+      ],
+      "cvssScore": 9.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-502"
+      ],
+      "description": "## Overview\nAffected versions of [`com.fasterxml.jackson.core:jackson-databind`](https://core.jackson.fasterxml.com) are vulnerable to Deserialization of Untrusted Data. An attacker may exploit this issue by sending a maliciously crafted input to the `readValue` method of the `ObjectMapper`.\n\n# Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n- Apache Blog\n\nThe vulnerability, also know as _Mad Gadget_\n> Mad Gadget is one of the most pernicious vulnerabilities we’ve seen. By merely existing on the Java classpath, seven “gadget” classes in Apache Commons Collections (versions 3.0, 3.1, 3.2, 3.2.1, and 4.0) make object deserialization for the entire JVM process Turing complete with an exec function. Since many business applications use object deserialization to send messages across the network, it would be like hiring a bank teller who was trained to hand over all the money in the vault if asked to do so politely, and then entrusting that teller with the key. The only thing that would keep a bank safe in such a circumstance is that most people wouldn’t consider asking such a question.\n- Google\n\n## Remediation\nUpgrade `com.fasterxml.jackson.core:jackson-databind` to version 2.8.9 or higher.\n\n## References\n- [Github PR](https://bugzilla.redhat.com/show_bug.cgi?id&#x3D;1462702)\n- [Github Issue](https://github.com/FasterXML/jackson-databind/issues/1599)\n- [Github Commit](https://github.com/FasterXML/jackson-databind/commit/60d459cedcf079c6106ae7da2ac562bc32dcabe1)\n",
+      "disclosureTime": "2017-04-10T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507",
+      "language": "java",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": "ObjectMapper",
+            "filePath": "com/fasterxml/jackson/databind/ObjectMapper.java",
+            "methodName": "enableDefaultTyping"
+          },
+          "version": [
+            "[,2.6.7.1)",
+            "[2.7,2.7.9.1)",
+            "[2.8,2.8.9)"
+          ]
+        }
+      ],
+      "modificationTime": "2018-12-20T13:09:36.378971Z",
+      "package": "com.fasterxml.jackson.core:jackson-databind",
+      "patchExists": false,
+      "publicationTime": "2017-09-14T14:43:48.569000Z",
+      "references": [
+        {
+          "title": "Github PR",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id&#x3D;1462702"
+        },
+        {
+          "title": "Github Issue",
+          "url": "https://github.com/FasterXML/jackson-databind/issues/1599"
+        },
+        {
+          "title": "Github Commit",
+          "url": "https://github.com/FasterXML/jackson-databind/commit/60d459cedcf079c6106ae7da2ac562bc32dcabe1"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "critical",
+      "title": "Deserialization of Untrusted Data",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507",
+      "vulnerableVersions": [
+        "[,2.6.7.1)",
+        "[2.7,2.7.9.1)",
+        "[2.8,2.8.9)"
+      ]
+    },
+    {
+      "creationTime": "2017-09-20T15:28:35.195000Z",
+      "credit": [
+        "Alessio Soldano"
+      ],
+      "cves": [],
+      "cvssScore": 5.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "cwes": [
+        "CWE-399"
+      ],
+      "description": "## Overview\r\n[`com.fasterxml.jackson.core:jackson-core`](https://github.com/FasterXML/jackson-core) is a core part of Jackson that defines Streaming API as well as basic shared abstractions.\r\n\r\nAffected versions of this package are vulnerable to Denial of Service attacks. \r\nIf the REST endpoint consumes POST requests with JSON or XML data and data are invalid, the first unrecognized token is printed to server.log\r\n> If the first token is word of length 10MB, the whole word is printed. This is potentially dangerous and can be used to attack the server by filling the disk with logs.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\r\n\r\n## Remediation\r\nUpgrade `com.fasterxml.jackson.core:jackson-core` to version `2.8.6` or higher.\r\n\r\n## References\r\n- [Github PR](https://github.com/FasterXML/jackson-core/pull/322)\r\n- [Jira Issue](https://issues.jboss.org/browse/JBEAP-6316)",
+      "disclosureTime": "2017-01-12T00:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-31519",
+      "language": "java",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": "UTF8StreamJsonParser",
+            "filePath": "com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java",
+            "methodName": "_reportInvalidToken"
+          },
+          "version": [
+            "[,2.8.6)"
+          ]
+        },
+        {
+          "methodId": {
+            "className": "ReaderBasedJsonParser",
+            "filePath": "com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java",
+            "methodName": "_reportInvalidToken"
+          },
+          "version": [
+            "[,2.8.6)"
+          ]
+        }
+      ],
+      "modificationTime": "2019-02-05T12:29:08.265741Z",
+      "package": "com.fasterxml.jackson.core:jackson-core",
+      "patchExists": false,
+      "publicationTime": "2017-09-20T15:28:35Z",
+      "references": [
+        {
+          "title": "Github PR",
+          "url": "https://github.com/FasterXML/jackson-core/pull/322"
+        },
+        {
+          "title": "Jira Issue",
+          "url": "https://issues.jboss.org/browse/JBEAP-6316"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "Denial of Service (DoS)",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31519",
+      "vulnerableVersions": [
+        "[,2.8.6)"
+      ]
+    },
+    {
+      "creationTime": "2016-12-25T16:51:56Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [
+        "CVE-2015-7501"
+      ],
+      "cvssScore": 9.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-502"
+      ],
+      "description": "## Overview\n[`commons-collections:commons-collections`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-collections%22)\nApache commons-collections library permitted code execution when deserializing objects involving a specially constructed chain of classes. A remote attacker could use this flaw to execute arbitrary code with the permissions of the application using the commons-collections library.\n\n# Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution. \n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n- Apache Blog\n \nThe vulnerability, also know as _Mad Gadget_ \n> Mad Gadget is one of the most pernicious vulnerabilities we’ve seen. By merely existing on the Java classpath, seven “gadget” classes in Apache Commons Collections (versions 3.0, 3.1, 3.2, 3.2.1, and 4.0) make object deserialization for the entire JVM process Turing complete with an exec function. Since many business applications use object deserialization to send messages across the network, it would be like hiring a bank teller who was trained to hand over all the money in the vault if asked to do so politely, and then entrusting that teller with the key. The only thing that would keep a bank safe in such a circumstance is that most people wouldn’t consider asking such a question.\n- Google \n\n\n## References\n- [breenmachine Blog](http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/)\n",
+      "disclosureTime": "2015-11-06T16:51:56Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-COMMONSCOLLECTIONS-30078",
+      "language": "java",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": "InvokerTransformer",
+            "filePath": "org/apache/commons/collections/functors/InvokerTransformer.java",
+            "methodName": "transform"
+          },
+          "version": [
+            "[3,3.2.2)"
+          ]
+        }
+      ],
+      "modificationTime": "2018-11-22T10:10:08.571223Z",
+      "package": "commons-collections:commons-collections",
+      "patchExists": false,
+      "publicationTime": "2015-11-06T16:51:56Z",
+      "references": [
+        {
+          "title": "breenmachine Blog",
+          "url": "http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "critical",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078",
+      "vulnerableVersions": [
+        "[3,3.2.2)"
+      ]
+    },
+    {
+      "creationTime": "2016-12-25T16:51:47Z",
+      "credit": [
+        "Karl Dyszynski",
+        "Hugo Vazquez Carames"
+      ],
+      "cves": [
+        "CVE-2013-0248"
+      ],
+      "cvssScore": 4.4,
+      "cvssV3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L",
+      "cwes": [
+        "CWE-264"
+      ],
+      "description": "## Overview\r\nAffected versions of [`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22) are vulnerable to Time of Check Time of Use (TOCTOU) attacks if the attacker has write access to the /tmp directory.\r\n\r\n## Details\r\nCommons FileUpload provides file upload capability for Servlets and web applications. During the upload process, FileUpload may (depending on configuration) save the uploaded file temporarily on disk. By default this will be in the system wide tmp directory. Because the temporary files have predictable file names and are stored in a publicly writeable location they are vulnerable to a TOCTOU attack.\r\n\r\nA successful attack requires that the attacker has write access to the tmp directory. The attack can be prevented by setting the repository to a non-publicly writeable location. The documentation for FileUpload does not highlight the potential security implications of not setting a repository, nor do the provided examples set a repository. This may have caused users to use FileUpload in an insecure manner.\r\n\r\n## Remediation\r\nUpgrade `commons-fileupload:commons-fileupload` to version 1.3 or higher.\n\n## References\n- [Commons-user Mailing List](http://mail-archives.apache.org/mod_mbox/commons-user/201303.mbox/%3C51371C31.8020805@apache.org%3E)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml#L114)\n- [Redhat Bugzilla](https://bugzilla.redhat.com/CVE-2013-0248)\n",
+      "disclosureTime": "2015-05-06T16:51:47Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30079",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-20T12:11:20.748048Z",
+      "package": "commons-fileupload:commons-fileupload",
+      "patchExists": false,
+      "publicationTime": "2015-05-06T16:51:47Z",
+      "references": [
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml#L114"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/CVE-2013-0248"
+        },
+        {
+          "title": "Commons-user Mailing List",
+          "url": "http://mail-archives.apache.org/mod_mbox/commons-user/201303.mbox/%3C51371C31.8020805@apache.org%3E"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "Time of Check Time of Use (TOCTOU)",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30079",
+      "vulnerableVersions": [
+        "[,1.3)"
+      ]
+    },
+    {
+      "creationTime": "2016-12-25T16:51:48Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [
+        "CVE-2013-2186"
+      ],
+      "cvssScore": 7.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "cwes": [
+        "CWE-20"
+      ],
+      "description": "## Overview\n[`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22)\nAffected versions of this package are vulnerable to Arbitrary File Write.\n\n## Details\nThe DiskFileItem class in Apache Commons FileUpload, as used in Red Hat JBoss BRMS 5.3.1; JBoss Portal 4.3 CP07, 5.2.2, and 6.0.0; and Red Hat JBoss Web Server 1.0.2 allows remote attackers to write to arbitrary files via a NULL byte in a file name in a serialized instance.\n\n## References\n- [Redhat Security Advisory](https://access.redhat.com/security/cve/CVE-2013-2186)\n- [Redhat Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2013-2186)\n",
+      "disclosureTime": "2013-06-16T16:51:48Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30080",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-19T10:10:07.871727Z",
+      "package": "commons-fileupload:commons-fileupload",
+      "patchExists": false,
+      "publicationTime": "2013-06-16T16:51:48Z",
+      "references": [
+        {
+          "title": "Redhat Security Advisory",
+          "url": "https://access.redhat.com/security/cve/CVE-2013-2186"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2013-2186"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "high",
+      "title": "Arbitrary File Write",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30080",
+      "vulnerableVersions": [
+        "[,1.3.1)"
+      ]
+    },
+    {
+      "creationTime": "2017-02-22T07:28:18.550000Z",
+      "credit": [
+        "guykoth"
+      ],
+      "cves": [
+        "CVE-2016-3674"
+      ],
+      "cvssScore": 7.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "cwes": [
+        "CWE-200"
+      ],
+      "description": "## Overview\r\n[`com.thoughtworks.xstream:xstream`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xstream%22) is a simple library to serialize objects to XML and back again.\r\nMultiple XML external entity (XXE) vulnerabilities in the (1) Dom4JDriver, (2) DomDriver, (3) JDomDriver, (4) JDom2Driver, (5) SjsxpDriver, (6) StandardStaxDriver, and (7) WstxDriver drivers in XStream before 1.4.9 allow remote attackers to read arbitrary files via a crafted XML document.\r\n\r\n## Details\r\n\r\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\r\n\r\n## References\r\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3674)\r\n- [OSS Security](http://www.openwall.com/lists/oss-security/2016/03/28/1)\r\n- [GitHub Issue](https://github.com/x-stream/xstream/issues/25)",
+      "disclosureTime": "2016-03-20T22:26:12Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-30385",
+      "language": "java",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": "Dom4JDriver",
+            "filePath": "com/thoughtworks/xstream/io/xml/Dom4JDriver.java",
+            "methodName": "createReader"
+          },
+          "version": [
+            "(,1.4.9)"
+          ]
+        },
+        {
+          "methodId": {
+            "className": "DomDriver",
+            "filePath": "com/thoughtworks/xstream/io/xml/DomDriver.java",
+            "methodName": "createReader"
+          },
+          "version": [
+            "(,1.4.9)"
+          ]
+        },
+        {
+          "methodId": {
+            "className": "JDom2Driver",
+            "filePath": "com/thoughtworks/xstream/io/xml/JDom2Driver.java",
+            "methodName": "createReader"
+          },
+          "version": [
+            "(,1.4.9)"
+          ]
+        },
+        {
+          "methodId": {
+            "className": "JDomDriver",
+            "filePath": "com/thoughtworks/xstream/io/xml/JDomDriver.java",
+            "methodName": "createReader"
+          },
+          "version": [
+            "(,1.4.9)"
+          ]
+        }
+      ],
+      "modificationTime": "2019-02-03T10:46:49.426865Z",
+      "package": "com.thoughtworks.xstream:xstream",
+      "patchExists": false,
+      "publicationTime": "2016-03-20T22:26:12Z",
+      "references": [
+        {
+          "title": "GitHub Commit Dom4JDriver",
+          "url": "https://github.com/x-stream/xstream/commit/5b5cd6d8137f645c5d57b648afb1a305967aa7f4"
+        },
+        {
+          "title": "GitHub Commit JDom",
+          "url": "https://github.com/x-stream/xstream/commit/696ec886a23dae880cf12e34e1fe09c5df8fe946"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3674"
+        },
+        {
+          "title": "OSS Security",
+          "url": "http://www.openwall.com/lists/oss-security/2016/03/28/1"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/x-stream/xstream/issues/25"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "high",
+      "title": "XML External Entity (XXE) Injection",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-30385",
+      "vulnerableVersions": [
+        "[,1.4.9)"
+      ]
+    },
+    {
+      "creationTime": "2018-05-30T12:32:02.349000Z",
+      "credit": [
+        "Snyk Security research Team"
+      ],
+      "cves": [
+        "CVE-2018-1002202"
+      ],
+      "cvssScore": 5.5,
+      "cvssV3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+      "cwes": [
+        "CWE-29"
+      ],
+      "description": "## Overview\r\n[`net.lingala.zip4j:zip4j`](http://mvnrepository.com/artifact/net.lingala.zip4j/zip4j) is an open source java library to handle zip files.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary File Write via Archive Extraction (AKA \"Zip Slip\").\r\n\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n\r\n## Remediation\r\nFix is available in [direct download](http://www.lingala.net/zip4j/includes/downloadzip4j.php?option=sources&fmt=zip) but not yet published.\n\n## References\n- [List of fixed projects that contained Zip Slip](https://github.com/snyk/zip-slip-vulnerability)\n- [Zip Slip Advisory](https://snyk.io/research/zip-slip-vulnerability)\n",
+      "disclosureTime": "2018-04-17T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-NETLINGALAZIP4J-31679",
+      "language": "java",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": "Unzip",
+            "filePath": "net/lingala/zip4j/unzip/Unzip.java",
+            "methodName": "initExtractFile"
+          },
+          "version": [
+            "[,1.3.3)"
+          ]
+        }
+      ],
+      "modificationTime": "2019-02-06T08:03:07.331333Z",
+      "package": "net.lingala.zip4j:zip4j",
+      "patchExists": false,
+      "publicationTime": "2018-05-31T07:32:02Z",
+      "references": [
+        {
+          "title": "Zip Slip Advisory",
+          "url": "https://snyk.io/research/zip-slip-vulnerability"
+        },
+        {
+          "title": "List of fixed projects that contained Zip Slip",
+          "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-NETLINGALAZIP4J-31679",
+      "vulnerableVersions": [
+        "[0,1.3.3)"
+      ]
+    },
+    {
+      "creationTime": "2017-02-22T07:28:21.294000Z",
+      "credit": [
+        "Matthias Kaiser"
+      ],
+      "cves": [
+        "CVE-2015-3269"
+      ],
+      "cvssScore": 5.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "cwes": [
+        "CWE-200"
+      ],
+      "description": "## Overview\n[`org.apache.flex.blazeds:flex-messaging-core`](https://github.com/apache/flex-blazeds) is an application development framework for easily building\nFlash-based applications for mobile devices, web browsers, and desktops.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. A remote attacker could read arbitrary files via an AMF message containing an XML external entity declaration in conjunction with an entity reference. An AMF message (Action Message Format) is a binary format used to serialize object graphs such as ActionScript objects and XML. The `readBody` method is used to parse the body of the AMF message,which in turn deserializes the message. Under certain conditions, the body is sent to be parsed in the `readXml()` method as a UTF string.\nThe `xml` string is then used to build a Document, via the `DocumentBuilder`, by using the `stringToDocument` method. The `DocumentBuilder` allows external entities by default, resulting in the possible XML External Entity (XXE) injection. \n\n## Details\n\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## References\n- [CodeWhiteSec Blog](http://codewhitesec.blogspot.co.il/2015/08/cve-2015-3269-apache-flex-blazeds-xxe.html)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-3269)\n",
+      "disclosureTime": "2015-08-19T23:00:10Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-30606",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:44.188417Z",
+      "package": "org.apache.flex.blazeds:flex-messaging-core",
+      "patchExists": false,
+      "publicationTime": "2015-08-19T23:00:10Z",
+      "references": [
+        {
+          "title": "CodeWhiteSec Blog",
+          "url": "http://codewhitesec.blogspot.co.il/2015/08/cve-2015-3269-apache-flex-blazeds-xxe.html"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-3269"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "XML External Entity (XXE) Injection",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-30606",
+      "vulnerableVersions": [
+        "[4.7.0]"
+      ]
+    },
+    {
+      "creationTime": "2017-02-22T07:28:21.308000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [
+        "CVE-2015-5255"
+      ],
+      "cvssScore": 4.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+      "cwes": [
+        "CWE-20"
+      ],
+      "description": "## Overview\n[`org.apache.flex.blazeds:flex-messaging-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22flex-messaging-core%22)\nAdobe BlazeDS, as used in ColdFusion 10 before Update 18 and 11 before Update 7 and LiveCycle Data Services 3.0.x before 3.0.0.354175, 3.1.x before 3.1.0.354180, 4.5.x before 4.5.1.354177, 4.6.2.x before 4.6.2.354178, and 4.7.x before 4.7.0.354178, allows remote attackers to send HTTP traffic to intranet servers via a crafted XML document, related to a Server-Side Request Forgery (SSRF) issue.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-5255)",
+      "disclosureTime": "2015-11-24T09:48:16.070000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-30607",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:44.190228Z",
+      "package": "org.apache.flex.blazeds:flex-messaging-core",
+      "patchExists": false,
+      "publicationTime": "2015-11-24T09:48:16.070000Z",
+      "references": [
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-5255"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "Improper Input Validation",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-30607",
+      "vulnerableVersions": [
+        "[4.7.0]"
+      ]
+    },
+    {
+      "creationTime": "2017-05-17T12:10:22.506000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [
+        "CVE-2017-5641"
+      ],
+      "cvssScore": 9.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\n[`org.apache.flex.blazeds:flex-messaging-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22flex-messaging-core%22)\nAffected versions of this package are vulnerable to Arbitrary Code Execution. It uses AMF3 deserializers which allow instantiation of arbitrary classes via public parameter-less constructors. An attacker may exploit this to send a malicious AMF3 object to the system to execute arbitrary code.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5641)\n- [Homeland Security](https://www.kb.cert.org/vuls/id/307983)\n",
+      "disclosureTime": "2017-04-06T08:05:24.436000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-31404",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:51.860094Z",
+      "package": "org.apache.flex.blazeds:flex-messaging-core",
+      "patchExists": false,
+      "publicationTime": "2017-05-21T07:52:37.342000Z",
+      "references": [
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5641"
+        },
+        {
+          "title": "Homeland Security",
+          "url": "https://www.kb.cert.org/vuls/id/307983"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "critical",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-31404",
+      "vulnerableVersions": [
+        "[4.7.0,4.7.2]"
+      ]
+    },
+    {
+      "creationTime": "2017-08-09T14:17:08.212000Z",
+      "credit": [
+        "Markus Wulftange"
+      ],
+      "cves": [
+        "CVE-2017-5641"
+      ],
+      "cvssScore": 9.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-502"
+      ],
+      "description": "## Overview\n[`org.apache.flex.blazeds:blazeds`](https://flex.apache.org/download-blazeds.html) is an application development framework for easily building Flash-based applications for mobile devices, web browsers, and desktops.\n\nThe AMF deserialization implementation of Flex BlazeDS is vulnerable to Deserialization of Untrusted Data. By sending a specially crafted AMF message, it is possible to make the server establish a connection to an endpoint specified in the message and request an RMI remote object from that endpoint. This can result in the execution of arbitrary code on the server via Java deserialization.\n\nStarting with BlazeDS version `4.7.3`, Deserialization of XML is disabled completely per default, while the `ClassDeserializationValidator` allows deserialization of whitelisted classes only. BlazeDS internally comes with the following whitelist:\n```\nflex.messaging.io.amf.ASObject\nflex.messaging.io.amf.SerializedObject\nflex.messaging.io.ArrayCollection\nflex.messaging.io.ArrayList\nflex.messaging.messages.AcknowledgeMessage\nflex.messaging.messages.AcknowledgeMessageExt\nflex.messaging.messages.AsyncMessage\nflex.messaging.messages.AsyncMessageExt\nflex.messaging.messages.CommandMessage\nflex.messaging.messages.CommandMessageExt\nflex.messaging.messages.ErrorMessage\nflex.messaging.messages.HTTPMessage\nflex.messaging.messages.RemotingMessage\nflex.messaging.messages.SOAPMessage\njava.lang.Boolean\njava.lang.Byte\njava.lang.Character\njava.lang.Double\njava.lang.Float\njava.lang.Integer\njava.lang.Long\njava.lang.Object\njava.lang.Short\njava.lang.String\njava.util.ArrayList\njava.util.Date\njava.util.HashMap\norg.w3c.dom.Document\n```\n\n## Remediation\nUpgrade `org.apache.flex.blazed:blazeds` to version 4.7.3 or higher.\n\n## References\n- [Github Release Notes](https://github.com/apache/flex-blazeds/blob/master/RELEASE_NOTES)\n- [Securitytracker Issue](http://www.securitytracker.com/id/1038364)\n- [CVE-2017-3066](https://nvd.nist.gov/vuln/detail/CVE-2017-3066)\n",
+      "disclosureTime": "2017-04-25T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-31455",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:45.449110Z",
+      "package": "org.apache.flex.blazeds:blazeds",
+      "patchExists": false,
+      "publicationTime": "2017-08-09T14:17:08.212000Z",
+      "references": [
+        {
+          "title": "Github Release Notes",
+          "url": "https://github.com/apache/flex-blazeds/blob/master/RELEASE_NOTES"
+        },
+        {
+          "title": "Securitytracker Issue",
+          "url": "http://www.securitytracker.com/id/1038364"
+        },
+        {
+          "title": "CVE-2017-3066",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-3066"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "high",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-31455",
+      "vulnerableVersions": [
+        "[,4.7.3)"
+      ]
+    },
+    {
+      "creationTime": "2017-08-31T07:52:54.488000Z",
+      "credit": [
+        "Wouter Coekaerts"
+      ],
+      "cves": [
+        "CVE-2011-2092"
+      ],
+      "cvssScore": 9.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-502"
+      ],
+      "description": "## Overview\r\n \r\n[org.apache.flex.blazeds:blazeds](https://github.com/apache/flex-blazeds) is an application development framework for easily building Flash-based applications for mobile devices, web browsers, and desktops.\r\n\r\n\r\nAffected versions of this package are vulnerable to Deserialization of Untrusted Data.\r\nAdobe LiveCycle Data Services 3.1 and earlier, LiveCycle 9.0.0.2 and earlier, and BlazeDS 4.0.1 and earlier do not properly restrict creation of classes during deserialization of (1) AMF and (2) AMFX data, which allows attackers to have an unspecified impact via unknown vectors, related to a \"deserialization vulnerability.\"\r\n\r\n## Details\r\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\r\n\r\n  \r\n\r\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\r\n\r\n  \r\n\r\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\r\n\r\n  \r\n\r\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\r\n\r\n  \r\n\r\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\r\n\r\n- Apache Blog\r\n\r\n  \r\n\r\nThe vulnerability, also know as _Mad Gadget_\r\n\r\n> Mad Gadget is one of the most pernicious vulnerabilities we’ve seen. By merely existing on the Java classpath, seven “gadget” classes in Apache Commons Collections (versions 3.0, 3.1, 3.2, 3.2.1, and 4.0) make object deserialization for the entire JVM process Turing complete with an exec function. Since many business applications use object deserialization to send messages across the network, it would be like hiring a bank teller who was trained to hand over all the money in the vault if asked to do so politely, and then entrusting that teller with the key. The only thing that would keep a bank safe in such a circumstance is that most people wouldn’t consider asking such a question.\r\n\r\n- Google\r\n\r\n## Remediation\r\n\r\nUpgrade org.apache.flex.blazeds:blazeds to version 4.0.1 or higher.\r\n\r\n\r\n## References\r\n\r\n- [Adobe Security Bulletin](http://www.adobe.com/support/security/bulletins/apsb11-15.html)\r\n\r\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2011-2093)\r\n",
+      "disclosureTime": "2011-06-13T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-31479",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-12-16T15:48:40.195675Z",
+      "package": "org.apache.flex.blazeds:blazeds",
+      "patchExists": false,
+      "publicationTime": "2017-08-31T14:12:24Z",
+      "references": [
+        {
+          "title": "Adobe Security Bulletin",
+          "url": "http://www.adobe.com/support/security/bulletins/apsb11-15.html"
+        },
+        {
+          "title": "NVD",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2011-2093"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "critical",
+      "title": "Deserialization of Untrusted Data",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-31479",
+      "vulnerableVersions": [
+        "[,4.0.1)"
+      ]
+    },
+    {
+      "creationTime": "2017-08-31T07:52:54.488000Z",
+      "credit": [
+        "Wouter Coekaerts"
+      ],
+      "cves": [
+        "CVE-2011-2093"
+      ],
+      "cvssScore": 5.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "cwes": [
+        "CWE-399"
+      ],
+      "description": "## Overview\r\n \r\n[org.apache.flex.blazeds:blazeds](https://github.com/apache/flex-blazeds) is an application development framework for easily building Flash-based applications for mobile devices, web browsers, and desktops.\r\n\r\n\r\nAffected versions of this package are vulnerable to Denial of Service (DoS).\r\nAdobe LiveCycle Data Services 3.1 and earlier, LiveCycle 9.0.0.2 and earlier, and BlazeDS 4.0.1 and earlier do not properly handle object graphs, which allows attackers to cause a denial of service via unspecified vectors, related to a \"complex object graph vulnerability.\"\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\r\n\r\n## Remediation\r\n\r\nUpgrade org.apache.flex.blazeds:blazeds to version 4.0.1 or higher.\r\n\r\n\r\n## References\r\n\r\n- [Github PR](http://www.adobe.com/support/security/bulletins/apsb11-15.html)\r\n\r\n- [Github Issue](https://nvd.nist.gov/vuln/detail/CVE-2011-2092)\r\n\r\n- [DoS attacks based on Object-Graph Engineering - A study by Jens Dietrich, Kamil Jezek, Shawn Rasheed, Amjed Tahir and Alex Potanin](http://drops.dagstuhl.de/opus/volltexte/2017/7260/pdf/LIPIcs-ECOOP-2017-10.pdf)\r\n",
+      "disclosureTime": "2011-06-13T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-31480",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-12-16T14:45:33.192643Z",
+      "package": "org.apache.flex.blazeds:blazeds",
+      "patchExists": false,
+      "publicationTime": "2017-08-31T14:12:24Z",
+      "references": [
+        {
+          "title": "Github PR",
+          "url": "http://www.adobe.com/support/security/bulletins/apsb11-15.html"
+        },
+        {
+          "title": "Github Issue",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2011-2092"
+        },
+        {
+          "title": "DoS attacks based on Object-Graph Engineering - A study by Jens Dietrich, Kamil Jezek, Shawn Rasheed, Amjed Tahir and Alex Potanin",
+          "url": "http://drops.dagstuhl.de/opus/volltexte/2017/7260/pdf/LIPIcs-ECOOP-2017-10.pdf"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "Denial of Service (DoS)",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEFLEXBLAZEDS-31480",
+      "vulnerableVersions": [
+        "[,4.0.1)"
+      ]
+    },
+    {
+      "creationTime": "2018-06-05T19:17:16.696000Z",
+      "credit": [
+        "Snyk Security research Team"
+      ],
+      "cves": [
+        "CVE-2018-8008"
+      ],
+      "cvssScore": 5.5,
+      "cvssV3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+      "cwes": [
+        "CWE-29"
+      ],
+      "description": "## Overview\r\n\r\n[org.apache.storm:storm-core](http://mvnrepository.com/artifact/org.apache.storm/storm-core) is a distributed realtime computation system.\r\n\r\n\r\nAffected versions of this package are vulnerable to Arbitrary File Write via Archive Extraction (Zip Slip).\r\n\r\n## Details\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n\r\n## Remediation\r\n\r\nUpgrade `org.apache.storm:storm-core` to version 1.1.3, 1.2.2 or higher.\r\n\r\n\r\n## References\r\n\r\n- [GitHub Commit](https://github.com/apache/storm/commit/1117a37b01a1058897a34e11ff5156e465efb692)\r\n\r\n- [Apache Mail Archives](https://lists.apache.org/thread.html/613b2fca8bcd0a3b12c0b763ea8f7cf62e422e9f79fce6cfa5b08a58@%3Cdev.storm.apache.org%3E)\r\n\r\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2018-8008)\r\n",
+      "disclosureTime": "2018-05-04T19:17:16Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGAPACHESTORM-32346",
+      "language": "java",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-02-06T08:03:07.673158Z",
+      "package": "org.apache.storm:storm-core",
+      "patchExists": false,
+      "publicationTime": "2018-06-06T15:07:50Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/storm/commit/1117a37b01a1058897a34e11ff5156e465efb692"
+        },
+        {
+          "title": "Apache Mail Archives",
+          "url": "https://lists.apache.org/thread.html/613b2fca8bcd0a3b12c0b763ea8f7cf62e422e9f79fce6cfa5b08a58@%3Cdev.storm.apache.org%3E"
+        },
+        {
+          "title": "NVD",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-8008"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTORM-32346",
+      "vulnerableVersions": [
+        "[,1.1.3)",
+        "[1.2.0,1.2.2)"
+      ]
+    },
+    {
+      "creationTime": "2017-03-19T10:28:21.873000Z",
+      "credit": [
+        "Nike Zheng"
+      ],
+      "cves": [
+        "CVE-2017-5638"
+      ],
+      "cvssScore": 10,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\r\n[`org.apache.struts:struts2-core`](https://cwiki.apache.org/confluence/display/WW/Home) is an elegant, extensible framework for building enterprise-ready Java web applications.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary Command Execution while uploading files with the Jakarta Multipart parser. This particular vulnerability can be exploited by an attacker by sending a crafted request to upload a file to the vulnerable server that uses a Jakarta-based plugin to process the upload request.\r\n\r\nThe attacker can then send malicious code in the `Content-Type`, `Content-Disposition` or `Content-Length` HTTP headers, which will then be executed by the vulnerable server. [A proof of concept](https://github.com/tengzhangchao/Struts2_045-Poc) that demonstrates the attack scenario is publicly available and the vulnerability is being [actively exploited in the wild](https://www.theregister.co.uk/2017/03/09/apache_under_attack_patch_for_zero_day_available/).\r\n\r\nAlthough maintainers of the open source project immediately patched the vulnerability, Struts servers that have yet to install the update remain under attack by hackers who exploit it to inject commands of their choice.\r\n\r\nThis attack can be achieved without authentication. To make matters worse, web applications don't necessarily need to successfully upload a malicious file to exploit this vulnerability, as just the presence of the vulnerable Struts library within an application is enough to exploit the vulnerability.\r\n\r\n## Remediation\r\nUpgrade `org.apache.struts:struts2-core` to version 2.3.32, 2.5.10.1 or higher.\n\n## References\n- [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5638)\n- [Exploit DB](https://www.exploit-db.com/exploits/41570/)\n- [Metasploit GitHub Commit](https://github.com/rapid7/metasploit-framework/pull/8072/commits/fc0f63e77471baa40057effaaa8be0f205adc6b7)\n- [Metasploit GitHub Issue](https://github.com/rapid7/metasploit-framework/issues/8064)\n- [Metasploit GitHub PR](https://github.com/rapid7/metasploit-framework/pull/8072)\n- [PoC](https://github.com/tengzhangchao/Struts2_045-Poc)\n- [Struts Wiki](https://cwiki.apache.org/confluence/display/WW/S2-045)\n- [Talos Intelligence Blog](http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html)\n",
+      "disclosureTime": "2017-03-05T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30207",
+      "language": "java",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": "JakartaMultiPartRequest",
+            "filePath": "org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java",
+            "methodName": "buildErrorMessage"
+          },
+          "version": [
+            "[2.3.0, 2.3.32)"
+          ]
+        },
+        {
+          "methodId": {
+            "className": "FileUploadInterceptor",
+            "filePath": "org/apache/struts2/interceptor/FileUploadInterceptor.java",
+            "methodName": "intercept"
+          },
+          "version": [
+            "[2.5,2.5.10.1)"
+          ]
+        }
+      ],
+      "modificationTime": "2019-02-06T08:03:06.445958Z",
+      "package": "org.apache.struts:struts2-core",
+      "patchExists": false,
+      "publicationTime": "2017-03-21T15:30:44Z",
+      "references": [
+        {
+          "title": "Metasploit GitHub PR",
+          "url": "https://github.com/rapid7/metasploit-framework/pull/8072"
+        },
+        {
+          "title": "Metasploit GitHub Issue",
+          "url": "https://github.com/rapid7/metasploit-framework/issues/8064"
+        },
+        {
+          "title": "Metasploit GitHub Commit",
+          "url": "https://github.com/rapid7/metasploit-framework/pull/8072/commits/fc0f63e77471baa40057effaaa8be0f205adc6b7"
+        },
+        {
+          "title": "PoC",
+          "url": "https://github.com/tengzhangchao/Struts2_045-Poc"
+        },
+        {
+          "title": "CVE",
+          "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5638"
+        },
+        {
+          "title": "Exploit DB",
+          "url": "https://www.exploit-db.com/exploits/41570/"
+        },
+        {
+          "title": "Struts Wiki",
+          "url": "https://cwiki.apache.org/confluence/display/WW/S2-045"
+        },
+        {
+          "title": "Talos Intelligence Blog",
+          "url": "http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "critical",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30207",
+      "vulnerableVersions": [
+        "[2.3.0, 2.3.32)",
+        "[2.5.0, 2.5.10.1)"
+      ]
+    },
+    {
+      "creationTime": "2018-05-30T12:32:02.349000Z",
+      "credit": [
+        "Snyk Security research Team"
+      ],
+      "cves": [
+        "CVE-2018-1002200"
+      ],
+      "cvssScore": 5.5,
+      "cvssV3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+      "cwes": [
+        "CWE-29"
+      ],
+      "description": "## Overview\r\n[`org.codehaus.plexus:plexus-archiver`](https://github.com/codehaus-plexus/plexus-archiver) is a Collection of Plexus components to create archives or extract files out of an archive to a directory with a unified Archiver/UnArchiver API whatever the archive format is.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary File Write via Archive Extraction (AKA \"Zip \r\nSlip\").\r\n\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n \r\n## Remediation\r\nUpgrade `org.codehaus.plexus:plexus-archiver`to version 3.6.0 or higher.\n\n## References\n- [GitHub Commit](https://github.com/codehaus-plexus/plexus-archiver/commit/f8f4233508193b70df33759ae9dc6154d69c2ea8)\n- [GitHub PR](https://github.com/codehaus-plexus/plexus-archiver/pull/87)\n- [List of fixed projects that contained Zip Slip](https://github.com/snyk/zip-slip-vulnerability)\n- [Zip Slip Advisory](https://snyk.io/research/zip-slip-vulnerability)\n",
+      "disclosureTime": "2018-04-17T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGCODEHAUSPLEXUS-31680",
+      "language": "java",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": "AbstractUnArchiver",
+            "filePath": "org/codehaus/plexus/archiver/AbstractUnArchiver.java",
+            "methodName": "extractFile"
+          },
+          "version": [
+            "[,3.6.0)"
+          ]
+        }
+      ],
+      "modificationTime": "2019-02-06T08:03:07.344499Z",
+      "package": "org.codehaus.plexus:plexus-archiver",
+      "patchExists": false,
+      "publicationTime": "2018-05-31T07:32:02Z",
+      "references": [
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/codehaus-plexus/plexus-archiver/pull/87"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/codehaus-plexus/plexus-archiver/commit/f8f4233508193b70df33759ae9dc6154d69c2ea8"
+        },
+        {
+          "title": "Zip Slip Advisory",
+          "url": "https://snyk.io/research/zip-slip-vulnerability"
+        },
+        {
+          "title": "List of fixed projects that contained Zip Slip",
+          "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31680",
+      "vulnerableVersions": [
+        "[,3.6.0)"
+      ]
+    },
+    {
+      "creationTime": "2018-07-27T14:48:04.592000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [
+        "CVE-2018-10862"
+      ],
+      "cvssScore": 5.5,
+      "cvssV3": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N",
+      "cwes": [
+        "CWE-22"
+      ],
+      "description": "## Overview\r\n[org.wildfly.core:wildfly-deployment-repository](https://github.com/wildfly/wildfly-core) provides the core runtime that is used by the Wildfly application server.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary File Write via Archive Extraction (AKA \"Zip Slip\").\r\n\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n\r\n## Remediation\r\nUpgrade `org.wildfly.core:wildfly-deployment-repository` to version 6.0.0 or higher.\n\n## References\n- [GitHub Commit](https://github.com/wildfly/wildfly-core/commit/40996ae6d5d3b6c1602a15f96b86a8d8a39b53eb)\n- [List of fixed projects that contained Zip Slip](https://github.com/snyk/zip-slip-vulnerability)\n- [Zip Slip Advisory](https://snyk.io/research/zip-slip-vulnerability)\n",
+      "disclosureTime": "2018-07-27T14:48:04Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGWILDFLYCORE-32441",
+      "language": "java",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": "PathUtil",
+            "filePath": "org/jboss/as/repository/PathUtil.java",
+            "methodName": "unzip"
+          },
+          "version": [
+            "[,6.0.0)"
+          ]
+        }
+      ],
+      "modificationTime": "2019-02-06T08:03:07.745640Z",
+      "package": "org.wildfly.core:wildfly-deployment-repository",
+      "patchExists": false,
+      "publicationTime": "2018-07-29T13:36:47Z",
+      "references": [
+        {
+          "title": "Zip Slip Advisory",
+          "url": "https://snyk.io/research/zip-slip-vulnerability"
+        },
+        {
+          "title": "List of fixed projects that contained Zip Slip",
+          "url": "https://github.com/snyk/zip-slip-vulnerability"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/wildfly/wildfly-core/commit/40996ae6d5d3b6c1602a15f96b86a8d8a39b53eb"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGWILDFLYCORE-32441",
+      "vulnerableVersions": [
+        "[,6.0.0)"
+      ]
+    },
+    {
+      "creationTime": "2018-05-30T12:32:02.349000Z",
+      "credit": [
+        "Snyk Security research Team"
+      ],
+      "cves": [
+        "CVE-2018-1002201"
+      ],
+      "cvssScore": 5.5,
+      "cvssV3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+      "cwes": [
+        "CWE-29"
+      ],
+      "description": "## Overview\r\n[`org.zeroturnaround:zt-zip`](https://github.com/zeroturnaround/zt-zip) is a library that helps to create, modify or extract ZIP archives.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary File Write via Archive Extraction (AKA \"Zip Slip\").\r\n\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n\r\n## Remediation\r\nUpgrade `org.zeroturnaround:zt-zip` to version 1.13 or higher.\n\n## References\n- [GitHub Commit](https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff)\n- [List of fixed projects that contained Zip Slip](https://github.com/snyk/zip-slip-vulnerability)\n- [Zip Slip Advisory](https://snyk.io/research/zip-slip-vulnerability)\n",
+      "disclosureTime": "2018-04-17T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JAVA-ORGZEROTURNAROUND-31681",
+      "language": "java",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": "Unpacker",
+            "filePath": "org/zeroturnaround/zip/ZipUtil$Unpacker.java",
+            "methodName": "process"
+          },
+          "version": [
+            "[,1.13)"
+          ]
+        }
+      ],
+      "modificationTime": "2019-02-06T08:03:07.358467Z",
+      "package": "org.zeroturnaround:zt-zip",
+      "patchExists": false,
+      "publicationTime": "2018-05-31T07:32:02Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff"
+        },
+        {
+          "title": "Zip Slip Advisory",
+          "url": "https://snyk.io/research/zip-slip-vulnerability"
+        },
+        {
+          "title": "List of fixed projects that contained Zip Slip",
+          "url": "https://github.com/snyk/zip-slip-vulnerability"
+        }
+      ],
+      "registry": "maven.org",
+      "severity": "medium",
+      "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+      "url": "https://snyk.io/vuln/SNYK-JAVA-ORGZEROTURNAROUND-31681",
+      "vulnerableVersions": [
+        "[,1.13)"
+      ]
+    }
+  ],
+  "js": [
+    {
+      "creationTime": "2016-11-28T18:44:12.405000Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cves": [
+        "CVE-2017-1000228"
+      ],
+      "cvssScore": 8.1,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\nAffected versions of the package are vulnerable to _Remote Code Execution_ by letting the attacker under certain conditions control the source folder from which the engine renders include files.\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\n\nThere's also a [Cross-site Scripting](https://snyk.io/vuln/npm:ejs:20161130) & [Denial of Service](https://snyk.io/vuln/npm:ejs:20161130-1) vulnerabilities caused by the same behaviour. \n\n## Details\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\n\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\n```js\nejs.render(str, data, options);\n\nejs.renderFile(filename, data, options, callback)\n```\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\n```js\nejs.render(str, dataAndOptions);\n\nejs.renderFile(filename, dataAndOptions, callback)\n```\n\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `root` option, which allows changing the project root for includes with an absolute path.  \n\n```js\nejs.renderFile('my-template', {root:'/bad/root/'}, callback);\n```\n\nBy passing along the root directive in the line above, any includes would now be pulled from `/bad/root` instead of the path intended. This allows the attacker to take control of the root directory for included scripts and divert it to a library under his control, thus leading to remote code execution.\n\nThe [fix](https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\n\n## Disclosure Timeline\n- November 27th, 2016 - Reported the issue to package owner.\n- November 27th, 2016 - Issue acknowledged by package owner.\n- November 28th, 2016 - Issue fixed and version `2.5.3` released.\n\n## Remediation\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\nOtherwise, Upgrade `ejs` to version `2.5.3` or higher.\n\n## References\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\n- [Fix commit](https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6)\n\n",
+      "disclosureTime": "2016-11-27T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-EJS-10218",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:07.015874Z",
+      "package": "ejs",
+      "patchExists": true,
+      "publicationTime": "2016-11-28T18:44:12.405000Z",
+      "references": [
+        {
+          "title": "Snyk Blog",
+          "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+        },
+        {
+          "title": "Fix commit",
+          "url": "https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-JS-EJS-10218",
+      "vulnerableVersions": [
+        "<2.5.3"
+      ]
+    },
+    {
+      "creationTime": "2016-11-28T18:44:12.405000Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cves": [
+        "CVE-2017-1000188"
+      ],
+      "cvssScore": 5.9,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "cwes": [
+        "CWE-79"
+      ],
+      "description": "## Overview\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\nAffected versions of the package are vulnerable to _Cross-site Scripting_ by letting the attacker under certain conditions control and override the `filename` option causing it to render the value as is, without escaping it.\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\n\nThere's also a [Remote Code Execution](https://snyk.io/vuln/npm:ejs:20161128) & [Denial of Service](https://snyk.io/vuln/npm:ejs:20161130-1) vulnerabilities caused by the same behaviour.\n\n## Details\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\n\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\n```js\nejs.render(str, data, options);\n\nejs.renderFile(filename, data, options, callback)\n```\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\n```js\nejs.render(str, dataAndOptions);\n\nejs.renderFile(filename, dataAndOptions, callback)\n```\n\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `filename` option, which will be rendered as is when an error occurs during rendering. \n\n```js\nejs.renderFile('my-template', {filename:'<script>alert(1)</script>'}, callback);\n```\n\nThe [fix](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\n\n## Disclosure Timeline\n- November 28th, 2016 - Reported the issue to package owner.\n- November 28th, 2016 - Issue acknowledged by package owner.\n- December 06th, 2016 - Issue fixed and version `2.5.5` released.\n\n## Remediation\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\nOtherwise, Upgrade `ejs` to version `2.5.5` or higher.\n\n## References\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\n- [Fix commit](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f)\n",
+      "disclosureTime": "2016-11-27T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-EJS-10225",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:06.995793Z",
+      "package": "ejs",
+      "patchExists": false,
+      "publicationTime": "2016-12-06T15:00:00Z",
+      "references": [
+        {
+          "title": "Snyk Blog",
+          "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+        },
+        {
+          "title": "Fix commit",
+          "url": "https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "url": "https://snyk.io/vuln/SNYK-JS-EJS-10225",
+      "vulnerableVersions": [
+        "<2.5.5"
+      ]
+    },
+    {
+      "creationTime": "2016-11-28T18:44:12.405000Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cves": [
+        "CVE-2017-1000189"
+      ],
+      "cvssScore": 5.9,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "cwes": [
+        "CWE-400"
+      ],
+      "description": "## Overview\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\nAffected versions of the package are vulnerable to _Denial of Service_ by letting the attacker under certain conditions control and override the `localNames` option causing it to crash.\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\n\nThere's also a [Remote Code Execution](https://snyk.io/vuln/npm:ejs:20161128) & [Cross-site Scripting](https://snyk.io/vuln/npm:ejs:20161130) vulnerabilities caused by the same behaviour.\n\n## Details\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\n\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\n```js\nejs.render(str, data, options);\n\nejs.renderFile(filename, data, options, callback)\n```\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\n```js\nejs.render(str, dataAndOptions);\n\nejs.renderFile(filename, dataAndOptions, callback)\n```\n\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `localNames` option, which will cause the renderer to crash.\n\n```js\nejs.renderFile('my-template', {localNames:'try'}, callback);\n```\n\nThe [fix](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\n\n## Disclosure Timeline\n- November 28th, 2016 - Reported the issue to package owner.\n- November 28th, 2016 - Issue acknowledged by package owner.\n- December 06th, 2016 - Issue fixed and version `2.5.5` released.\n\n## Remediation\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\nOtherwise, Upgrade `ejs` to version `2.5.5` or higher.\n\n## References\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\n- [Fix commit](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f)\n",
+      "disclosureTime": "2016-11-27T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-EJS-10226",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:06.965266Z",
+      "package": "ejs",
+      "patchExists": false,
+      "publicationTime": "2016-12-06T15:00:00Z",
+      "references": [
+        {
+          "title": "Snyk Blog",
+          "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+        },
+        {
+          "title": "Fix commit",
+          "url": "https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "Denial of Service (DoS)",
+      "url": "https://snyk.io/vuln/SNYK-JS-EJS-10226",
+      "vulnerableVersions": [
+        "<2.5.5"
+      ]
+    },
+    {
+      "creationTime": "2018-01-25T13:56:29.281000Z",
+      "credit": [
+        "Zeke Sikelianos"
+      ],
+      "cves": [
+        "CVE-2018-1000006"
+      ],
+      "cvssScore": 9.6,
+      "cvssV3": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:H/RL:O/RC:C",
+      "cwes": [
+        "CWE-22"
+      ],
+      "description": "## Overview\n[`electron`](https://www.npmjs.com/package/electron) is a framework that lets you write cross-platform desktop applications using JavaScript, HTML and CSS. \n\nElectron apps running on Windows that register themselves as the default handler for a protocol, like myapp://, are vulnerable.\n\nSuch apps can be affected regardless of how the protocol is registered, e.g. using native code, the Windows registry, or Electron's app.setAsDefaultProtocolClient API.\n\n**Note:** MacOS and Linux are not affected by this vulnerability.\n\n## Details\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\r\n\r\nDirectory Traversal vulnerabilities can be generally divided into two types:\r\n\r\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\r\n\r\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\r\n\r\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\r\n\r\n```\r\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\r\n```\r\n**Note** `%2e` is the URL encoded version of `.` (dot).\r\n\r\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \r\n\r\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n2018-04-15 22:04:29 .....           19           19  good.txt\r\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\r\n```\n\n\n## Remediation\nUpgrade `electron` to version 1.6.16, 1.7.11 or higher.\n\n## References\n- [Electron Vulnerability Advisory](https://electronjs.org/blog/protocol-handler-fix)\n- [GitHub PR](https://github.com/electron/electron/pull/12294)",
+      "disclosureTime": "2018-01-23T22:00:00Z",
+      "exploit": "High",
+      "fixable": true,
+      "id": "SNYK-JS-ELECTRON-10873",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:41.629505Z",
+      "package": "electron",
+      "patchExists": false,
+      "publicationTime": "2018-01-25T13:56:29.281000Z",
+      "references": [
+        {
+          "title": "Electron Vulnerability Advisory",
+          "url": "https://electronjs.org/blog/protocol-handler-fix"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/electron/electron/pull/12294"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "critical",
+      "title": "Directory Traversal",
+      "url": "https://snyk.io/vuln/SNYK-JS-ELECTRON-10873",
+      "vulnerableVersions": [
+        "<1.6.16 || >=1.7 <1.7.11 || >=1.8 <1.8.2-beta.4"
+      ]
+    },
+    {
+      "creationTime": "2019-02-03T09:18:05.060741Z",
+      "credit": [
+        "cristianstaicu"
+      ],
+      "cves": [],
+      "cvssScore": 4.4,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:H/UI:N/S:U/C:N/I:N/A:H",
+      "cwes": [
+        "CWE-185"
+      ],
+      "description": "## Overview\r\n\r\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\r\n\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS).\r\nIt parses dates using regex strings, which may cause a slowdown of 2 seconds per 50k characters.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n## Remediation\r\n\r\nUpgrade `lodash` to version 4.17.11 or higher.\r\n\r\n\r\n## References\r\n\r\n- [GitHub Commit](https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347)\r\n\r\n- [GitHub Issue](https://github.com/lodash/lodash/issues/3359)\r\n",
+      "disclosureTime": "2017-09-05T09:14:29Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-LODASH-73639",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-02-03T14:29:55.545804Z",
+      "package": "lodash",
+      "patchExists": false,
+      "publicationTime": "2019-02-03T09:14:22Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/lodash/lodash/issues/3359"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "url": "https://snyk.io/vuln/SNYK-JS-LODASH-73639",
+      "vulnerableVersions": []
+    },
+    {
+      "creationTime": "2014-01-30T22:33:12Z",
+      "credit": [
+        "Xiao Long"
+      ],
+      "cves": [
+        "CVE-2015-1370"
+      ],
+      "cvssScore": 6.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+      "cwes": [
+        "CWE-74"
+      ],
+      "description": "## Overview\n\nMarked 0.3.2 and earlier is vulnerable to content injection even when `sanitize: true` is enabled.\n\n`[xss link](vbscript:alert(1&#41;)`\n\nwill get a link\n\n`<a href=\"vbscript:alert(1)\">xss link</a>`\n\nThis script does not work in IE 11 edge mode, but works in IE 10 compatibility view.\n\n_Source: [Node Security Project](https://nodesecurity.io/advisories/24)_\n\n## Remediation\n\nUpgrade to version 0.3.3 or greater.\n\n## References\n\n- https://github.com/chjj/marked/issues/492\n",
+      "disclosureTime": "2014-01-30T22:33:12Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-MARKED-10008",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-21T10:10:08.425469Z",
+      "package": "marked",
+      "patchExists": true,
+      "publicationTime": "2014-01-30T22:33:12Z",
+      "references": [
+        {
+          "title": "GITHUB.COM",
+          "url": "https://github.com/chjj/marked/issues/492"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "VBScript Content Injection",
+      "url": "https://snyk.io/vuln/SNYK-JS-MARKED-10008",
+      "vulnerableVersions": [
+        "<=0.3.2"
+      ]
+    },
+    {
+      "creationTime": "2014-01-30T22:33:12Z",
+      "credit": [
+        "Barış Soner Uşaklı"
+      ],
+      "cves": [],
+      "cvssScore": 7.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "cwes": [
+        "CWE-185",
+        "CWE-730"
+      ],
+      "description": "## Overview\n[marked](https://github.com/markedjs/marked) is a markdown parser and compiler. Built for speed.\n\nAffected versions of this package are vulnerable to Regular Expressions Denial of Service (ReDoS) when certain types of input are passed in to be parsed.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n\n## Remediation\nUgrade to marked v0.3.4 or later.\n\n## References\n- [GitHub Issue](https://github.com/chjj/marked/issues/497)\n",
+      "disclosureTime": "2014-01-30T22:33:12Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-MARKED-10009",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-21T10:10:06.570449Z",
+      "package": "marked",
+      "patchExists": true,
+      "publicationTime": "2014-01-30T22:33:12Z",
+      "references": [
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/chjj/marked/issues/497"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Regular Expression Denial of Service (DoS)",
+      "url": "https://snyk.io/vuln/SNYK-JS-MARKED-10009",
+      "vulnerableVersions": [
+        "<=0.3.3"
+      ]
+    },
+    {
+      "creationTime": "2014-01-30T22:33:12Z",
+      "credit": [
+        "Adam Baldwin"
+      ],
+      "cves": [
+        "CVE-2014-1850",
+        "CVE-2014-3743"
+      ],
+      "cvssScore": 6.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+      "cwes": [
+        "CWE-74"
+      ],
+      "description": "## Overview\nMarked comes with an option to sanitize user output to help protect against content injection attacks.\n\nsanitize: true\n\nEven if this option is set, marked is vulnerable to content injection in multiple locations if untrusted user input is allowed to be provided into marked and that output is passed to the browser.\n\nInjection is possible in two locations\n- gfm codeblocks (language)\n- javascript url's\n\n_Source: [Node Security Project](https://nodesecurity.io/advisories/22)_\n\n## Remediation\nUpgrade to version 0.3.1 or later\n\n## References\n\n",
+      "disclosureTime": "2014-01-30T22:33:12Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-MARKED-10010",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-20T10:10:11.005775Z",
+      "package": "marked",
+      "patchExists": false,
+      "publicationTime": "2014-01-30T22:33:12Z",
+      "references": [],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "Multiple Content Injection Vulnerabilities",
+      "url": "https://snyk.io/vuln/SNYK-JS-MARKED-10010",
+      "vulnerableVersions": [
+        "<=0.3.0"
+      ]
+    },
+    {
+      "creationTime": "2016-04-20T14:45:19.556000Z",
+      "credit": [
+        "Matt Austin"
+      ],
+      "cves": [
+        "CVE-2016-10531"
+      ],
+      "cvssScore": 8.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-79"
+      ],
+      "description": "## Overview\n[`marked`](https://www.npmjs.com/package/marked) is a markdown parser and compiler used for rendering markdown content to html. \n\nIt is vulnerable to content injection attack allowing the attacker to bypass its output sanitization (`sanitize: true`) protection. Using the [HTML Coded Character Set](https://www.w3.org/MarkUp/html-spec/html-spec_13.html#SEC13), attackers can inject `javascript:` code snippets into the output. For example, the following input `javascript&#x58document;alert&#40;1&#41;`  will result in `alert(1)` being executed when the user clicks on the link.\n\n## Details\nCross-Site Scripting (XSS) attacks occur when an attacker tricks a user’s browser to execute malicious JavaScript code in the context of a victim’s domain. Such scripts can steal the user’s session cookies for the domain, scrape or modify its content, and perform or modify actions on the user’s behalf, actions typically blocked by the browser’s Same Origin Policy.\r\n\r\nThese attacks are possible by escaping the context of the web application and injecting malicious scripts in an otherwise trusted website. These scripts can introduce additional attributes (say, a \"new\" option in a dropdown list or a new link to a malicious site) and can potentially execute code on the clients side, unbeknown to the victim. This occurs when characters like `<` `>` `\"` `'` are not escaped properly.\r\n\r\nThere are a few types of XSS:\r\n- **Persistent XSS** is an attack in which the malicious code persists into the web app’s database.\r\n- **Reflected XSS** is an which the website echoes back a portion of the request. The attacker needs to trick the user into clicking a malicious link (for instance through a phishing email or malicious JS on another page), which triggers the XSS attack.\r\n- **DOM-based XSS** is an that occurs purely in the browser when client-side JavaScript echoes back a portion of the URL onto the page. DOM-Based XSS is notoriously hard to detect, as the server never gets a chance to see the attack taking place.\n\n\n## Remediation\nUpgrade `marked` to version 0.3.6 or higher.\nAlso, you can patch the vulnerability using [Snyk wizard](https://snyk.io/docs/using-snyk/#wizard).\n\n## References\n- [GitHub PR](https://github.com/chjj/marked/pull/592)\n- [GitHub Commit](https://github.com/chjj/marked/pull/592/commits/2cff85979be8e7a026a9aca35542c470cf5da523)\n",
+      "disclosureTime": "2015-05-20T16:45:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-MARKED-10099",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:07.971288Z",
+      "package": "marked",
+      "patchExists": true,
+      "publicationTime": "2016-04-20T14:45:19.556000Z",
+      "references": [
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/chjj/marked/pull/592"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/chjj/marked/pull/592/commits/2cff85979be8e7a026a9aca35542c470cf5da523"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Content & Code Injection (XSS)",
+      "url": "https://snyk.io/vuln/SNYK-JS-MARKED-10099",
+      "vulnerableVersions": [
+        "<0.3.6"
+      ]
+    },
+    {
+      "creationTime": "2017-01-12T00:00:00.780000Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cves": [
+        "CVE-2017-1000427"
+      ],
+      "cvssScore": 7.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "cwes": [
+        "CWE-79"
+      ],
+      "description": "## Overview\n[`marked`](https://www.npmjs.com/package/marked) is a markdown parser and compiler used for rendering markdown content to html.\n\nAffected versions of the package are vulnerable to Cross-site Scripting (XSS). Data URIs enable embedding small files in line in HTML documents, provided in the URL itself.\nAttackers can craft malicious web pages containing either HTML or script code that utilizes the data URI scheme, allowing them to bypass access controls or steal sensitive information.\n\nAn example of data URI used to deliver javascript code. The data holds `<script>alert('XSS')</script>` tag in base64 encoded format.\n```html\n[xss link](data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4K)\n``` \n\n## Details\nCross-Site Scripting (XSS) attacks occur when an attacker tricks a user’s browser to execute malicious JavaScript code in the context of a victim’s domain. Such scripts can steal the user’s session cookies for the domain, scrape or modify its content, and perform or modify actions on the user’s behalf, actions typically blocked by the browser’s Same Origin Policy.\r\n\r\nThese attacks are possible by escaping the context of the web application and injecting malicious scripts in an otherwise trusted website. These scripts can introduce additional attributes (say, a \"new\" option in a dropdown list or a new link to a malicious site) and can potentially execute code on the clients side, unbeknown to the victim. This occurs when characters like `<` `>` `\"` `'` are not escaped properly.\r\n\r\nThere are a few types of XSS:\r\n- **Persistent XSS** is an attack in which the malicious code persists into the web app’s database.\r\n- **Reflected XSS** is an which the website echoes back a portion of the request. The attacker needs to trick the user into clicking a malicious link (for instance through a phishing email or malicious JS on another page), which triggers the XSS attack.\r\n- **DOM-based XSS** is an that occurs purely in the browser when client-side JavaScript echoes back a portion of the URL onto the page. DOM-Based XSS is notoriously hard to detect, as the server never gets a chance to see the attack taking place.\n\n\n## Remediation\nUpgrade `marked` to version 0.3.7 or higher.\nAlso, you can patch the vulnerability using [Snyk wizard](https://snyk.io/docs/using-snyk/#wizard).\n\n## References\n- [GitHub Commit](https://github.com/chjj/marked/commit/cd2f6f5b7091154c5526e79b5f3bfb4d15995a51)\n",
+      "disclosureTime": "2017-01-12T00:00:00.780000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-MARKED-10377",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:07.557213Z",
+      "package": "marked",
+      "patchExists": true,
+      "publicationTime": "2017-01-30T18:00:00.780000Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/chjj/marked/commit/cd2f6f5b7091154c5526e79b5f3bfb4d15995a51"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Cross-site Scripting (XSS) via Data URIs",
+      "url": "https://snyk.io/vuln/SNYK-JS-MARKED-10377",
+      "vulnerableVersions": [
+        "<0.3.7"
+      ]
+    },
+    {
+      "creationTime": "2017-09-21T08:07:51.834000Z",
+      "credit": [
+        "Cristian-Alexandru Staicu"
+      ],
+      "cves": [
+        "CVE-2017-16114"
+      ],
+      "cvssScore": 7.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "cwes": [
+        "CWE-400"
+      ],
+      "description": "## Overview\n[`marked`](https://www.npmjs.com/package/marked) is a full-featured markdown parser and compiler.\n\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks when parsing the input markdown content (1,000 characters costs around 6 seconds matching time).\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n\n## Remediation\nUpgrade `marked` to version 0.3.9 or higher.\nIn the meantime, you can patch the vulnerability using [Snyk wizard](https://snyk.io/docs/using-snyk/#wizard).\n\n## References\n- [Github Issue](https://github.com/chjj/marked/issues/937)\n- [GitHub Issue - Release 0.3.9 status](https://github.com/chjj/marked/pull/958)\n",
+      "disclosureTime": "2017-09-07T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-MARKED-10782",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-21T10:10:07.968667Z",
+      "package": "marked",
+      "patchExists": true,
+      "publicationTime": "2017-09-21T08:07:51.834000Z",
+      "references": [
+        {
+          "title": "Github Issue",
+          "url": "https://github.com/chjj/marked/issues/937"
+        },
+        {
+          "title": "GitHub Issue - Release 0.3.9 status",
+          "url": "https://github.com/chjj/marked/pull/958"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "url": "https://snyk.io/vuln/SNYK-JS-MARKED-10782",
+      "vulnerableVersions": [
+        "<0.3.9"
+      ]
+    },
+    {
+      "creationTime": "2018-01-10T20:47:00.775000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [
+        "CVE-2018-0114"
+      ],
+      "cvssScore": 7.1,
+      "cvssV3": "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N/E:H/RL:O/RC:C",
+      "cwes": [
+        "CWE-347"
+      ],
+      "description": "## Overview\n[`node-jose`](https://www.npmjs.com/package/node-jose) is a JavaScript implementation of the JSON Object Signing and Encryption (JOSE) for current web browsers and node.js-based servers.\n\nA vulnerability in the Cisco node-jose open source library before 0.11.0 could allow an unauthenticated, remote attacker to re-sign tokens using a key that is embedded within the token. The vulnerability is due to node-jose following the JSON Web Signature (JWS) standard for JSON Web Tokens (JWTs). This standard specifies that a JSON Web Key (JWK) representing a public key can be embedded within the header of a JWS. This public key is then trusted for verification. An attacker could exploit this by forging valid JWS objects by removing the original signature, adding a new public key to the header, and then signing the object using the (attacker-owned) private key associated with the public key embedded in that JWS header.\n## References\n- [GitHub Changelog](https://github.com/cisco/node-jose/blob/master/CHANGELOG.md)\n- [Cisco Vulnerability Alert](https://tools.cisco.com/security/center/viewAlert.x?alertId=56326)\n",
+      "disclosureTime": "2017-12-22T20:47:00.775000Z",
+      "exploit": "High",
+      "fixable": true,
+      "id": "SNYK-JS-NODEJOSE-12040",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:42.086901Z",
+      "package": "node-jose",
+      "patchExists": false,
+      "publicationTime": "2018-01-10T20:47:00.775000Z",
+      "references": [
+        {
+          "title": "GitHub Changelog",
+          "url": "https://github.com/cisco/node-jose/blob/master/CHANGELOG.md"
+        },
+        {
+          "title": "Cisco Vulnerability Alert",
+          "url": "https://tools.cisco.com/security/center/viewAlert.x?alertId=56326"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Insecure Token Validation",
+      "url": "https://snyk.io/vuln/SNYK-JS-NODEJOSE-12040",
+      "vulnerableVersions": [
+        "<0.11.0"
+      ]
+    },
+    {
+      "creationTime": "2014-08-06T06:10:22Z",
+      "credit": [
+        "Dustin Shiver"
+      ],
+      "cves": [
+        "CVE-2014-7191"
+      ],
+      "cvssScore": 7.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "cwes": [
+        "CWE-400"
+      ],
+      "description": "## Overview\n[`qs`](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Denial of Service (Dos) attacks. During parsing, the `qs` module may create a sparse area (an array where no elements are filled), and grow that array to the necessary size based on the indices used on it. An attacker can specify a high index value in a query string, thus making the server allocate a respectively big array. Truly large values can cause the server to run out of memory and cause it to crash - thus enabling a Denial-of-Service attack.\n\n## Remediation\nUpgrade qs to version 1.0.0 or greater. In these versions, qs introduced a low limit on the index value, preventing such an attack\n\n## References\n- [GitHub Issue](https://github.com/visionmedia/node-querystring/issues/104)\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2014-7191)",
+      "disclosureTime": "2014-08-06T06:10:22Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-QS-10019",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:06.155388Z",
+      "package": "qs",
+      "patchExists": true,
+      "publicationTime": "2014-08-06T06:10:22Z",
+      "references": [
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/visionmedia/node-querystring/issues/104"
+        },
+        {
+          "title": "NVD",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7191"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Denial of Service (Memory Exhaustion)",
+      "url": "https://snyk.io/vuln/SNYK-JS-QS-10019",
+      "vulnerableVersions": [
+        "<1.0.0"
+      ]
+    },
+    {
+      "creationTime": "2014-08-06T06:10:23Z",
+      "credit": [
+        "Tom Steele"
+      ],
+      "cves": [
+        "CVE-2014-10064"
+      ],
+      "cvssScore": 6.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+      "cwes": [
+        "CWE-400"
+      ],
+      "description": "## Overview\n[`qs`](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). When parsing a string representing a deeply nested object, qs will block the event loop for long periods of time. Such a delay may hold up the server's resources, keeping it from processing other requests in the meantime, thus enabling a Denial-of-Service attack. \n\n## Remediation\nUpdate qs to version 1.0.0 or higher. In these versions, qs enforces a max object depth (along with other limits), limiting the event loop length and thus preventing such an attack.\n\n## References\n- [Node Security Advisory](https://nodesecurity.io/advisories/28)",
+      "disclosureTime": "2014-08-06T06:10:23Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-QS-10020",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:06.136104Z",
+      "package": "qs",
+      "patchExists": true,
+      "publicationTime": "2014-08-06T06:10:23Z",
+      "references": [
+        {
+          "title": "Node Security Advisory",
+          "url": "https://nodesecurity.io/advisories/28"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "Denial of Service (Event Loop Blocking)",
+      "url": "https://snyk.io/vuln/SNYK-JS-QS-10020",
+      "vulnerableVersions": [
+        "<1.0.0"
+      ]
+    },
+    {
+      "creationTime": "2017-02-14T11:44:54.163000Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cves": [
+        "CVE-2017-1000048"
+      ],
+      "cvssScore": 7.4,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+      "cwes": [
+        "CWE-20"
+      ],
+      "description": "## Overview\r\n[`qs`](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\r\n\r\nBy default `qs` protects against attacks that attempt to overwrite an object's existing prototype properties, such as `toString()`, `hasOwnProperty()`,etc.\r\n\r\nFrom [`qs` documentation](https://github.com/ljharb/qs):\r\n> By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.\r\n\r\nOverwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.\r\n\r\nIn versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with `[` or `]`. e.g. `qs.parse(\"]=toString\")` will return `{toString = true}`, as a result, calling `toString()` on the object will throw an exception.\r\n\r\n**Example:**\r\n```js\r\nqs.parse('toString=foo', { allowPrototypes: false })\r\n// {}\r\n\r\nqs.parse(\"]=toString\", { allowPrototypes: false })\r\n// {toString = true} <== prototype overwritten\r\n```\r\n\r\nFor more information, you can check out our [blog](https://snyk.io/blog/high-severity-vulnerability-qs/).\r\n\r\n## Disclosure Timeline\r\n- February 13th, 2017 - Reported the issue to package owner.\r\n- February 13th, 2017 - Issue acknowledged by package owner.\r\n- February 16th, 2017 - Partial fix released in versions `6.0.3`, `6.1.1`, `6.2.2`, `6.3.1`.\r\n- March 6th, 2017     - Final fix released in versions `6.4.0`,`6.3.2`, `6.2.3`, `6.1.2` and `6.0.4`\r\n\r\n## Remediation\r\nUpgrade `qs` to version `6.4.0` or higher.\r\n**Note:** The fix was backported to the following versions `6.3.2`, `6.2.3`, `6.1.2`, `6.0.4`.\r\n\r\n## References\r\n- [GitHub Commit](https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d)\r\n- [Report of an insufficient fix](https://github.com/ljharb/qs/issues/200)",
+      "disclosureTime": "2017-02-13T00:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-QS-10407",
+      "language": "js",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": null,
+            "filePath": "lib/parse.js",
+            "methodName": "internals.parseObject"
+          },
+          "version": [
+            "<6.0.4"
+          ]
+        },
+        {
+          "methodId": {
+            "className": null,
+            "filePath": "lib/parse.js",
+            "methodName": "internals.parseObject"
+          },
+          "version": [
+            ">=6.1.0 <6.1.2"
+          ]
+        },
+        {
+          "methodId": {
+            "className": null,
+            "filePath": "lib/parse.js",
+            "methodName": "parseObject"
+          },
+          "version": [
+            ">=6.2.0 <6.2.3"
+          ]
+        },
+        {
+          "methodId": {
+            "className": null,
+            "filePath": "lib/parse.js",
+            "methodName": "parseObjectRecursive"
+          },
+          "version": [
+            ">=6.3.0 <6.3.2"
+          ]
+        }
+      ],
+      "modificationTime": "2019-01-10T12:57:34.683966Z",
+      "package": "qs",
+      "patchExists": true,
+      "publicationTime": "2017-03-01T10:00:54Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d"
+        },
+        {
+          "title": "Report of an insufficient fix",
+          "url": "https://github.com/ljharb/qs/issues/200"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Prototype Override Protection Bypass",
+      "url": "https://snyk.io/vuln/SNYK-JS-QS-10407",
+      "vulnerableVersions": [
+        "<6.0.4",
+        ">=6.1.0 <6.1.2",
+        ">=6.2.0 <6.2.3",
+        ">=6.3.0 <6.3.2"
+      ]
+    },
+    {
+      "creationTime": "2016-03-22T12:00:05.158000Z",
+      "credit": [
+        "Feross Aboukhadijeh"
+      ],
+      "cves": [
+        "CVE-2017-16026"
+      ],
+      "cvssScore": 5.1,
+      "cvssV3": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "cwes": [
+        "CWE-201"
+      ],
+      "description": "## Overview\r\n\r\n[request](https://www.npmjs.com/package/request) is a simplified http request client.\r\n\r\n\r\nAffected versions of this package are vulnerable to Remote Memory Exposure.\r\nA potential remote memory exposure vulnerability exists in `request`. If a `request` uses a multipart attachment and the _body type_ option is `number` with value X, then X bytes of uninitialized memory will be sent in the body of the request.\r\n\r\nNote that while the impact of this vulnerability is high (memory exposure), exploiting it is likely difficult, as the attacker needs to somehow control the body type of the request. One potential exploit scenario is when a request is composed based on JSON input, including the body type, allowing a malicious JSON to trigger the memory leak.\r\n\r\n## Details\r\nConstructing a `Buffer` class with integer `N` creates a `Buffer`\r\nof length `N` with non zero-ed out memory.\r\n**Example:**\r\n```js\r\nvar x = new Buffer(100); // uninitialized Buffer of length 100\r\n// vs\r\nvar x = new Buffer('100'); // initialized Buffer with value of '100'\r\n```\r\n\r\nInitializing a multipart body in such manner will cause uninitialized memory to be sent in the body of the request.\r\n\r\n#### Proof of concept\r\n```js\r\nvar http = require('http')\r\nvar request = require('request')\r\n\r\nhttp.createServer(function (req, res) {\r\n  var data = ''\r\n  req.setEncoding('utf8')\r\n  req.on('data', function (chunk) {\r\n    console.log('data')\r\n    data += chunk\r\n  })\r\n  req.on('end', function () {\r\n    // this will print uninitialized memory from the client\r\n    console.log('Client sent:\\n', data)\r\n  })\r\n  res.end()\r\n}).listen(8000)\r\n\r\nrequest({\r\n  method: 'POST',\r\n  uri: 'http://localhost:8000',\r\n  multipart: [{ body: 1000 }]\r\n},\r\nfunction (err, res, body) {\r\n  if (err) return console.error('upload failed:', err)\r\n  console.log('sent')\r\n})\r\n```\r\n\r\n## Remediation\r\n\r\nUpgrade `request` to version 2.68.0 or higher.\r\n\r\n\r\n## References\r\n\r\n- [GitHub Fixed Commit](https://github.com/request/request/pull/2018/commits/3d31d4526fa4d4e4f59b89cabe194fb671063cdb)\r\n\r\n- [GitHub PR](https://github.com/request/request/pull/2018)\r\n\r\n- [Blog: Node Buffer API fix](https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md#previous-materials)\r\n\r\n- [Blog: Information about Buffer](https://github.com/ChALkeR/notes/blob/master/Buffer-knows-everything.md)\r\n",
+      "disclosureTime": "2016-01-19T04:57:05Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-REQUEST-10088",
+      "language": "js",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": null,
+            "filePath": "lib/multipart.js",
+            "methodName": "Multipart.prototype.build.add"
+          },
+          "version": [
+            ">2.2.5 <2.68.0"
+          ]
+        }
+      ],
+      "modificationTime": "2019-01-20T13:44:04.801808Z",
+      "package": "request",
+      "patchExists": true,
+      "publicationTime": "2016-03-22T12:00:05Z",
+      "references": [
+        {
+          "title": "GitHub Fixed Commit",
+          "url": "https://github.com/request/request/pull/2018/commits/3d31d4526fa4d4e4f59b89cabe194fb671063cdb"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/request/request/pull/2018"
+        },
+        {
+          "title": "Blog: Node Buffer API fix",
+          "url": "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md#previous-materials"
+        },
+        {
+          "title": "Blog: Information about Buffer",
+          "url": "https://github.com/ChALkeR/notes/blob/master/Buffer-knows-everything.md"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "Remote Memory Exposure",
+      "url": "https://snyk.io/vuln/SNYK-JS-REQUEST-10088",
+      "vulnerableVersions": [
+        ">2.2.5 <2.68.0"
+      ]
+    },
+    {
+      "creationTime": "2014-02-06T07:33:48Z",
+      "credit": [
+        "Charlie Somerville"
+      ],
+      "cves": [
+        "CVE-2014-3744"
+      ],
+      "cvssScore": 5.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "cwes": [
+        "CWE-22"
+      ],
+      "description": "## Overview\r\nVersions prior to 0.2.5 did not properly prevent path traversal. Literal dots in a path were resolved out, but url encoded dots were not. Thus, a request like ``` /%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd ``` would leak sensitive files and data from the server.\r\n\r\nAs of version 0.2.5, any ```'/../'``` in the request path, urlencoded or not, will be replaced with ```'/'```. If your application depends on url traversal, then you are encouraged to please refactor so that you do not depend on having ```..``` in url paths, as this tends to expose data that you may be surprised to be exposing.\r\n\r\n## Details\r\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\r\n\r\nDirectory Traversal vulnerabilities can be generally divided into two types:\r\n\r\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\r\n\r\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\r\n\r\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\r\n\r\n```\r\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\r\n```\r\n**Note** `%2e` is the URL encoded version of `.` (dot).\r\n\r\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \r\n\r\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n2018-04-15 22:04:29 .....           19           19  good.txt\r\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\r\n```\r\n\r\n\r\n## Remediation\r\nUpgrade to version 0.2.5 or greater.\r\n\r\n## References\r\n- https://github.com/isaacs/st#security-status\r\n- http://blog.npmjs.org/post/80277229932/newly-paranoid-maintainers",
+      "disclosureTime": "2014-02-06T07:33:48Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-ST-10012",
+      "language": "js",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": null,
+            "filePath": "st.js",
+            "methodName": "Mount.prototype.getPath"
+          },
+          "version": [
+            "<0.2.5"
+          ]
+        }
+      ],
+      "modificationTime": "2018-11-21T10:10:07.194217Z",
+      "package": "st",
+      "patchExists": true,
+      "publicationTime": "2014-02-06T07:33:48Z",
+      "references": [
+        {
+          "title": "GITHUB.COM",
+          "url": "https://github.com/isaacs/st#security-status"
+        },
+        {
+          "title": "BLOG.NPMJS.ORG",
+          "url": "http://blog.npmjs.org/post/80277229932/newly-paranoid-maintainers"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "Directory Traversal",
+      "url": "https://snyk.io/vuln/SNYK-JS-ST-10012",
+      "vulnerableVersions": [
+        "<0.2.5"
+      ]
+    },
+    {
+      "creationTime": "2019-02-10T14:45:37.461294Z",
+      "credit": [
+        "Yeiniel Suarez Sosa"
+      ],
+      "cves": [],
+      "cvssScore": 7.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "cwes": [
+        "CWE-506"
+      ],
+      "description": "## Overview\r\n\r\n[stream-combine](https://www.npmjs.com/package/stream-combine) is a merges chronological time-based streams.\r\n\r\n\r\nAffected versions of this package are vulnerable to Malicious Package.\r\nThe code contains malicious functions design to steal credentials and credit card information by searching different forms of passwords, credit card numbers and CVC codes. Then, the information is being uploaded to a remote server using HTML links embedded in the page or form actions. \r\nNote: If your application has Content Security Policy set you are not affected by this issue.\r\n\r\n## Remediation\r\n\r\nAvoid using `stream-combine` altogether.\r\n\r\n\r\n## References\r\n\r\n- [NPM Security Advisory](https://www.npmjs.com/advisories/774)\r\n",
+      "disclosureTime": "2019-01-25T14:44:54Z",
+      "exploit": "Not Defined",
+      "fixable": false,
+      "id": "SNYK-JS-STREAMCOMBINE-173670",
+      "language": "js",
+      "malicious": true,
+      "methods": [],
+      "modificationTime": "2019-02-10T15:43:39.360925Z",
+      "package": "stream-combine",
+      "patchExists": false,
+      "publicationTime": "2019-02-10T14:44:56Z",
+      "references": [
+        {
+          "title": "NPM Security Advisory",
+          "url": "https://www.npmjs.com/advisories/774"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Malicious Package",
+      "url": "https://snyk.io/vuln/SNYK-JS-STREAMCOMBINE-173670",
+      "vulnerableVersions": [
+        "=2.0.2"
+      ]
+    },
+    {
+      "creationTime": "2017-09-27T11:38:25.465000Z",
+      "credit": [
+        "Dennis Appelt"
+      ],
+      "cves": [
+        "CVE-2017-16129"
+      ],
+      "cvssScore": 3.7,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "cwes": [
+        "CWE-400"
+      ],
+      "description": "## Overview\n[`superagent`](https://www.npmjs.com/package/superagent) is elegant & feature rich browser / node HTTP with a fluent API.\n\nAffected versions of the package are vulnerable to Denial of Service (DoS) attacks. It uncompresses responses in memory, and a malicious user may send a specially crafted zip file which will then unzip in the server and cause excessive CPU consumption. This is also known as a `Zip Bomb`.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `superagent` to version 3.7.0 or higher.\n\n## References\n- [Github PR](https://github.com/visionmedia/superagent/issues/1259)\n",
+      "disclosureTime": "2017-08-06T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-SUPERAGENT-10789",
+      "language": "js",
+      "malicious": false,
+      "methods": [
+        {
+          "methodId": {
+            "className": null,
+            "filePath": "lib/node/index.js",
+            "methodName": "Request.prototype._end"
+          },
+          "version": [
+            "<3.7.0"
+          ]
+        },
+        {
+          "methodId": {
+            "className": null,
+            "filePath": "lib/node/index.js",
+            "methodName": "Request.prototype.end"
+          },
+          "version": [
+            "<3.4.0"
+          ]
+        }
+      ],
+      "modificationTime": "2019-01-20T14:41:32.949277Z",
+      "package": "superagent",
+      "patchExists": false,
+      "publicationTime": "2017-09-27T11:38:25.465000Z",
+      "references": [
+        {
+          "title": "Github PR",
+          "url": "https://github.com/visionmedia/superagent/issues/1259"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "low",
+      "title": "Denial of Service (DoS)",
+      "url": "https://snyk.io/vuln/SNYK-JS-SUPERAGENT-10789",
+      "vulnerableVersions": [
+        "*"
+      ]
+    },
+    {
+      "creationTime": "2016-01-05T12:38:01.749000Z",
+      "credit": [
+        "Feross Aboukhadijeh",
+        "Mathias Buss Madsen"
+      ],
+      "cves": [
+        "CVE-2016-10518"
+      ],
+      "cvssScore": 6.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+      "cwes": [
+        "CWE-201"
+      ],
+      "description": "## Overview\n[`ws`](https://www.npmjs.com/package/ws) is a simple to use websocket client, server and console for node.js.\nAffected versions of the package are vulnerable to Uninitialized Memory Exposure.\n\nA client side memory disclosure vulnerability exists in ping functionality of the ws service. When a client sends a ping request and provides an integer value as ping data, it will result in leaking an uninitialized memory buffer.\n\nThis is a result of unobstructed use of the `Buffer` constructor, whose [insecure default constructor increases the odds of memory leakage](https://snyk.io/blog/exploiting-buffer/).\n\n`ws`'s `ping` function uses the default `Buffer` constructor as-is, making it easy to append uninitialized memory to an existing list. If the value of the buffer list is exposed to users, it may expose raw memory, potentially holding secrets, private data and code.\n\n**Proof of Concept:**\n```js\nvar ws = require('ws')\n\nvar server = new ws.Server({ port: 9000 })\nvar client = new ws('ws://localhost:9000')\n\nclient.on('open', function () {\n  console.log('open')\n  client.ping(50) // this makes the client allocate an uninitialized buffer of 50 bytes and send it to the server\n\n  client.on('pong', function (data) {\n    console.log('got pong')\n    console.log(data)\n  })\n})\n```\n\n## Details\nThe Buffer class on Node.js is a mutable array of binary data, and can be initialized with a string, array or number.\r\n```js\r\nconst buf1 = new Buffer([1,2,3]);\r\n// creates a buffer containing [01, 02, 03]\r\nconst buf2 = new Buffer('test');\r\n// creates a buffer containing ASCII bytes [74, 65, 73, 74]\r\nconst buf3 = new Buffer(10);\r\n// creates a buffer of length 10\r\n```\r\n\r\nThe first two variants simply create a binary representation of the value it received. The last one, however, pre-allocates a buffer of the specified size, making it a useful buffer, especially when reading data from a stream.\r\nWhen using the number constructor of Buffer, it will allocate the memory, but will not fill it with zeros. Instead, the allocated buffer will hold whatever was in memory at the time. If the buffer is not `zeroed` by using `buf.fill(0)`, it may leak sensitive information like keys, source code, and system info.\n\n\nSimilar vulnerabilities were discovered in [request](https://snyk.io/vuln/npm:request:20160119), [mongoose](https://snyk.io/vuln/npm:mongoose:20160116), [ws](https://snyk.io/vuln/npm:ws:20160104) and [sequelize](https://snyk.io/vuln/npm:sequelize:20160115).\n\n## References\n- [GitHub Release](https://github.com/websockets/ws/releases/tag/1.0.1)\n- [GitHub Issue](https://github.com/nodejs/node-v0.x-archive/issues/4525)\n",
+      "disclosureTime": "2016-01-04T19:34:19.734000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-WS-10072",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:06.818552Z",
+      "package": "ws",
+      "patchExists": true,
+      "publicationTime": "2016-01-05T12:38:01.749000Z",
+      "references": [
+        {
+          "title": "GitHub Release",
+          "url": "https://github.com/websockets/ws/releases/tag/1.0.1"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/nodejs/node-v0.x-archive/issues/4525"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "Remote Memory Exposure",
+      "url": "https://snyk.io/vuln/SNYK-JS-WS-10072",
+      "vulnerableVersions": [
+        "< 1.0.1"
+      ]
+    },
+    {
+      "creationTime": "2016-06-24T18:00:02.350000Z",
+      "credit": [
+        "Fedor Indutny"
+      ],
+      "cves": [
+        "CVE-2016-10542"
+      ],
+      "cvssScore": 7.5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "cwes": [
+        "CWE-410"
+      ],
+      "description": "## Overview\n[`ws`](https://www.npmjs.com/package/ws) is a WebSocket client and server implementation.\n\n Affected versions of this package did not limit the size of an incoming payload before it was processed by default. As a result, a very large payload (over 256MB in size) could lead to a failed allocation and crash the node process - enabling a [Denial of Service](https://en.wikipedia.org/wiki/Denial-of-service_attack) attack.\n\nWhile 256MB may seem excessive, note that the attack is likely to be sent from another server, not an end-user computer, using data-center connection speeds. In those speeds, a payload of this size can be transmitted in seconds.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpdate to version 1.1.1 or greater, which sets a default `maxPayload` of 100MB.\nIf you cannot upgrade, apply a Snyk patch, or provide `ws` with options setting the `maxPayload` to an appropriate size that is smaller than 256MB.\n\n## References\n- [WS Issue](https://github.com/websockets/ws/commit/0328a8f49f004f98d2913016214e93b2fc2713bc)\n- [Resulting crash in Node](https://github.com/nodejs/node/issues/7388)",
+      "disclosureTime": "2016-06-24T17:13:33Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-WS-10111",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:06.317397Z",
+      "package": "ws",
+      "patchExists": true,
+      "publicationTime": "2016-06-26T17:13:33Z",
+      "references": [
+        {
+          "title": "WS Issue",
+          "url": "https://github.com/websockets/ws/commit/0328a8f49f004f98d2913016214e93b2fc2713bc"
+        },
+        {
+          "title": "Resulting crash in Node",
+          "url": "https://github.com/nodejs/node/issues/7388"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "high",
+      "title": "Denial of Service (DoS)",
+      "url": "https://snyk.io/vuln/SNYK-JS-WS-10111",
+      "vulnerableVersions": [
+        "<=1.1.0"
+      ]
+    },
+    {
+      "creationTime": "2016-11-23T13:12:00.207000Z",
+      "credit": [
+        "AJ ONeal"
+      ],
+      "cves": [],
+      "cvssScore": 5.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "cwes": [
+        "CWE-330"
+      ],
+      "description": "## Overview\n[`ws`](https://www.npmjs.com/package/ws) is a simple to use websocket client, server and console for node.js.\n\nAffected versions of the package use the cryptographically insecure `Math.random()` which can produce predictable values and should not be used in security-sensitive context.\n\n### Details\nComputers are deterministic machines, and as such are unable to produce true randomness. Pseudo-Random Number Generators (PRNGs) approximate randomness algorithmically, starting with a seed from which subsequent values are calculated.\n\nThere are two types of PRNGs: statistical and cryptographic. Statistical PRNGs provide useful statistical properties, but their output is highly predictable and forms an easy to reproduce numeric stream that is unsuitable for use in cases where security depends on generated values being unpredictable. Cryptographic PRNGs address this problem by generating output that is more difficult to predict. For a value to be cryptographically secure, it must be impossible or highly improbable for an attacker to distinguish between it and a truly random value. In general, if a PRNG algorithm is not advertised as being cryptographically secure, then it is probably a statistical PRNG and should not be used in security-sensitive contexts.\n\nYou can read more about node's insecure `Math.random()` in [Mike Malone's post](https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d).\n\n## Remediation\nUpgrade `ws` to version 1.1.2 or higher.\n\n## References\n- [GitHub PR](https://github.com/websockets/ws/pull/832)\n- [GitHub Commit](https://github.com/websockets/ws/commit/7253f06f5432c76f3e82e2c055fcea08b612d8b2)\n- [Mike Malone's Blog](https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d#.6wcldperq)\n",
+      "disclosureTime": "2016-09-19T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-JS-WS-10399",
+      "language": "js",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:07.618931Z",
+      "package": "ws",
+      "patchExists": true,
+      "publicationTime": "2017-02-07T18:12:00.207000Z",
+      "references": [
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/websockets/ws/pull/832"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/websockets/ws/commit/7253f06f5432c76f3e82e2c055fcea08b612d8b2"
+        },
+        {
+          "title": "Mike Malone's Blog",
+          "url": "https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d#.6wcldperq"
+        }
+      ],
+      "registry": "npmjs.org",
+      "severity": "medium",
+      "title": "Insecure Randomness",
+      "url": "https://snyk.io/vuln/SNYK-JS-WS-10399",
+      "vulnerableVersions": [
+        "<1.1.2"
+      ]
+    }
+  ],
+  "php": [
+    {
+      "creationTime": "2019-01-27T13:26:10.559800Z",
+      "credit": [
+        "YU-HSIANG HUANG",
+        "YUNG-HAO TSENG",
+        "Eddie TC CHANG"
+      ],
+      "cves": [
+        "CVE-2019-6798"
+      ],
+      "cvssScore": 7.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "cwes": [
+        "CWE-89"
+      ],
+      "description": "## Overview\r\n\r\n[phpmyadmin/phpmyadmin](https://packagist.org/packages/phpmyadmin/phpmyadmin) is a web interface for MySQL and MariaDB.\r\n\r\n\r\nAffected versions of this package are vulnerable to SQL Injection\r\nvia the designer feature.\r\n\r\n## Remediation\r\n\r\nUpgrade `phpmyadmin/phpmyadmin` to version 4.8.5 or higher.\r\n\r\n\r\n## References\r\n\r\n- [GitHub Commit](https://github.com/phpmyadmin/phpmyadmin/commit/469934cf7d3bd19a839eb78670590f7511399435)\r\n\r\n- [PhpMyAdmin Security Advisory](https://www.phpmyadmin.net/security/PMASA-2019-2/)\r\n",
+      "disclosureTime": "2019-01-26T17:35:25Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PHP-PHPMYADMINPHPMYADMIN-73616",
+      "language": "php",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-01-27T15:23:55.823016Z",
+      "package": "phpmyadmin/phpmyadmin",
+      "patchExists": false,
+      "publicationTime": "2019-01-26T17:35:25Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/phpmyadmin/phpmyadmin/commit/469934cf7d3bd19a839eb78670590f7511399435"
+        },
+        {
+          "title": "PhpMyAdmin Security Advisory",
+          "url": "https://www.phpmyadmin.net/security/PMASA-2019-2/"
+        }
+      ],
+      "registry": "packagist.org",
+      "severity": "high",
+      "title": "SQL Injection",
+      "url": "https://snyk.io/vuln/SNYK-PHP-PHPMYADMINPHPMYADMIN-73616",
+      "vulnerableVersions": [
+        ">=4.5.0, <4.8.5"
+      ]
+    },
+    {
+      "creationTime": "2019-01-24T12:12:00.725005Z",
+      "credit": [
+        "Edgar Boda-Majer and Lauritz Holtmann"
+      ],
+      "cves": [],
+      "cvssScore": 9.9,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H/E:F/RL:O/RC:C",
+      "cwes": [
+        "CWE-79"
+      ],
+      "description": "## Overview\r\n\r\n[typo3/cms-core](https://packagist.org/packages/typo3/cms-core) is an open source enterprise content management system.\r\n\r\n\r\nAffected versions of this package are vulnerable to Arbitrary Code Execution.\r\nDue to missing file extensions in `$GLOBALS['TYPO3_CONF_VARS']['BE'][‘fileDenyPattern’]`, backend users are allowed to upload `*.phar`, `*.shtml`, `*.pl` or `*.cgi` files which can be executed in certain web server setups.\r\n\r\n## Remediation\r\n\r\nUpgrade `typo3/cms-core` to version 8.7.23, 9.5.4 or higher.\r\n\r\n\r\n## References\r\n\r\n- [Typo3 Security Advisory](https://typo3.org/security/advisory/typo3-core-sa-2019-008/)\r\n",
+      "disclosureTime": "2019-01-22T19:35:56Z",
+      "exploit": "Functional",
+      "fixable": true,
+      "id": "SNYK-PHP-TYPO3CMSCORE-73589",
+      "language": "php",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-01-24T16:14:28.312505Z",
+      "package": "typo3/cms-core",
+      "patchExists": false,
+      "publicationTime": "2019-01-22T19:35:56Z",
+      "references": [
+        {
+          "title": "Typo3 Security Advisory",
+          "url": "https://typo3.org/security/advisory/typo3-core-sa-2019-008/"
+        }
+      ],
+      "registry": "packagist.org",
+      "severity": "critical",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-PHP-TYPO3CMSCORE-73589",
+      "vulnerableVersions": [
+        ">=8.0.0, <8.7.23",
+        ">=9.0.0, <9.5.4"
+      ]
+    },
+    {
+      "creationTime": "2019-02-06T08:44:45.764193Z",
+      "credit": [
+        "chenjj"
+      ],
+      "cves": [
+        "CVE-2018-20745"
+      ],
+      "cvssScore": 5.6,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "cwes": [
+        "CWE-346"
+      ],
+      "description": "## Overview\r\n\r\n[yiisoft/yii2](https://packagist.org/packages/yiisoft/yii2) is a Yii PHP Framework.\r\n\r\n\r\nAffected versions of this package are vulnerable to Broken CORS (Cross-Origin Resource Sharing).\r\nIt converts a wildcard `CORS` policy into reflecting an arbitrary origin header value, which is incompatible with the `CORS` security design, and could lead to `CORS` misconfiguration security problems.\r\n\r\n## Remediation\r\n\r\nUpgrade `yiisoft/yii2` to version 2.0.16 or higher.\r\n\r\n\r\n## References\r\n\r\n- [GitHub Commit](https://github.com/yiisoft/yii2/commit/3317d26df0497c2f1a7f8fb9d1c668d911ab284f)\r\n\r\n- [GitHub Issue](https://github.com/yiisoft/yii2/issues/16193)\r\n",
+      "disclosureTime": "2019-01-28T08:42:47Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PHP-YIISOFTYII2-73651",
+      "language": "php",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-02-10T14:31:47.585178Z",
+      "package": "yiisoft/yii2",
+      "patchExists": false,
+      "publicationTime": "2019-02-10T12:59:58Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/yiisoft/yii2/commit/3317d26df0497c2f1a7f8fb9d1c668d911ab284f"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/yiisoft/yii2/issues/16193"
+        }
+      ],
+      "registry": "packagist.org",
+      "severity": "medium",
+      "title": "Broken CORS (Cross-Origin Resource Sharing)",
+      "url": "https://snyk.io/vuln/SNYK-PHP-YIISOFTYII2-73651",
+      "vulnerableVersions": [
+        "<2.0.16"
+      ]
+    }
+  ],
+  "python": [
+    {
+      "creationTime": "2017-05-28T08:10:34.096000Z",
+      "credit": [
+        "Maxime Beauchemin"
+      ],
+      "cves": [],
+      "cvssScore": 5.6,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\r\n[`airflow`](https://pypi.python.org/pypi/airflow) is a Programmatically author, schedule and monitor data pipelines.\r\n\r\nAffected versions of this package are vulnerable to Arbitrary Code Execution attacks due to a flaw in the code that evaluates a variable improperly, allowing an attacker to hijack the interpreter.\r\n\r\n## References\r\n- [Jira Issue](https://issues.apache.org/jira/browse/AIRFLOW-231)\r\n- [GitHub PR](https://github.com/apache/incubator-airflow/pull/1584)\r\n- [GitHub Commit](https://github.com/apache/incubator-airflow/commit/7d29698b639d9e2060465aa778efb842986df706)\r\n",
+      "disclosureTime": "2016-06-10T07:24:52.538000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-AIRFLOW-40467",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:47.499005Z",
+      "package": "airflow",
+      "patchExists": false,
+      "publicationTime": "2016-06-10T07:24:52.538000Z",
+      "references": [
+        {
+          "title": "Jira Issue",
+          "url": "https://issues.apache.org/jira/browse/AIRFLOW-231"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/apache/incubator-airflow/pull/1584"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/incubator-airflow/commit/7d29698b639d9e2060465aa778efb842986df706"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "medium",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-AIRFLOW-40467",
+      "vulnerableVersions": [
+        "[,1.8)"
+      ]
+    },
+    {
+      "creationTime": "2017-05-28T08:10:35.491000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [],
+      "cvssScore": 7.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\r\n[`airflow`](https://pypi.python.org/pypi/airflow) is a Programmatically author, schedule and monitor data pipelines.\r\n\r\nAffected versions of this package are vulnerable to Arbitrary Code Execution. User input is sent unchecked to the the python `eval` function which directly executes the parameters. Any user who can create or edit charts may execute arbitrary code on the server.\r\n\r\n## References\r\n- [Jira Issue](https://issues.apache.org/jira/browse/AIRFLOW-933)\r\n- [GitHub PR](https://github.com/apache/incubator-airflow/pull/2117)\r\n- [GitHub Commit](https://github.com/apache/incubator-airflow/commit/88d9b0dc96e7528c87326c8070ee276e8565545f)\r\n",
+      "disclosureTime": "2017-03-03T07:06:37.251000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-AIRFLOW-40616",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:48.017439Z",
+      "package": "airflow",
+      "patchExists": false,
+      "publicationTime": "2017-03-03T07:06:37.251000Z",
+      "references": [
+        {
+          "title": "Jira Issue",
+          "url": "https://issues.apache.org/jira/browse/AIRFLOW-933"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/apache/incubator-airflow/pull/2117"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/incubator-airflow/commit/88d9b0dc96e7528c87326c8070ee276e8565545f"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "high",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-AIRFLOW-40616",
+      "vulnerableVersions": [
+        "[,1.8.0)"
+      ]
+    },
+    {
+      "creationTime": "2017-05-28T08:10:35.548000Z",
+      "credit": [
+        "Rui Wang"
+      ],
+      "cves": [],
+      "cvssScore": 5,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\r\n[`airflow`](https://pypi.python.org/pypi/airflow) is a Programmatically author, schedule and monitor data pipelines.\r\n\r\nAffected versions of this package are vulnerable to Arbitrary Code Execution. Anyone able to modify the application's underlying database, or a computer where certain DAG tasks are executed, may execute arbitrary code on the Airflow host.\r\n\r\n## References\r\n- [Jira Issue](https://issues.apache.org/jira/browse/AIRFLOW-855)\r\n- [GitHub PR](https://github.com/apache/incubator-airflow/pull/2132)\r\n",
+      "disclosureTime": "2017-03-08T14:11:00.035000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-AIRFLOW-40619",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:48.024395Z",
+      "package": "airflow",
+      "patchExists": false,
+      "publicationTime": "2017-03-08T14:11:00.035000Z",
+      "references": [
+        {
+          "title": "Jira Issue",
+          "url": "https://issues.apache.org/jira/browse/AIRFLOW-855"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/apache/incubator-airflow/pull/2132"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "medium",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-AIRFLOW-40619",
+      "vulnerableVersions": [
+        "[,1.8.1]"
+      ]
+    },
+    {
+      "creationTime": "2018-08-28T19:19:12.417000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [
+        "CVE-2018-14572"
+      ],
+      "cvssScore": 7.8,
+      "cvssV3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\n[conference-scheduler-cli](https://pypi.org/project/conference-scheduler-cli/) is a command line tool to manage the schedule for a conference.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution via a crafted `.pickle` file.\n\n## Remediation\nThere is no fix version for `conference-scheduler-cli`.\n\n## References\n- [Github Issue](https://github.com/PyconUK/ConferenceScheduler-cli/issues/19)\n",
+      "disclosureTime": "2018-07-24T19:19:12.417000Z",
+      "exploit": "Not Defined",
+      "fixable": false,
+      "id": "SNYK-PYTHON-CONFERENCESCHEDULERCLI-42186",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-02-06T08:03:07.945903Z",
+      "package": "conference-scheduler-cli",
+      "patchExists": false,
+      "publicationTime": "2018-08-30T14:30:31.019000Z",
+      "references": [
+        {
+          "title": "Github Issue",
+          "url": "https://github.com/PyconUK/ConferenceScheduler-cli/issues/19"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "high",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-CONFERENCESCHEDULERCLI-42186",
+      "vulnerableVersions": [
+        "[0,]"
+      ]
+    },
+    {
+      "creationTime": "2017-04-13T12:32:00Z",
+      "credit": [
+        "Benjamin Bach"
+      ],
+      "cves": [
+        "CVE-2014-0472"
+      ],
+      "cvssScore": 5.6,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\r\n[`Django`](https://pypi.python.org/pypi/Django) is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.\r\n\r\nAffected versions of this package are vulnerable to Arbitrary Code Execution attacks. The `django.core.urlresolvers.reverse` function allows remote attackers to import and execute arbitrary Python modules by leveraging a view that constructs URLs using user input and a \"dotted Python path.\"\r\n\r\n## Remediation\r\nUpgrade to versions `1.7b2`, `1.6.3`, `1.5.6`, `1.4.11` or greater.\r\n\r\n## References\r\n- [Django Vulnerability Description](https://www.djangoproject.com/weblog/2014/apr/21/security/)\r\n- [Redhat Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0472)\r\n- [Redhat Vulnerability Advisory](https://rhn.redhat.com/errata/RHSA-2014-0456.html)\r\n",
+      "disclosureTime": "2014-04-23T12:32:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-DJANGO-40025",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:46.992737Z",
+      "package": "django",
+      "patchExists": false,
+      "publicationTime": "2014-04-23T12:32:00Z",
+      "references": [
+        {
+          "title": "Django Vulnerability Description",
+          "url": "https://www.djangoproject.com/weblog/2014/apr/21/security/"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0472"
+        },
+        {
+          "title": "Redhat Vulnerability Advisory",
+          "url": "https://rhn.redhat.com/errata/RHSA-2014-0456.html"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "medium",
+      "title": "Arbitrary Code Execution",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-DJANGO-40025",
+      "vulnerableVersions": [
+        "[,1.4.11), [1.5,1.5.6), [1.6,1.6.3), [1.7,1.7b2)"
+      ]
+    },
+    {
+      "creationTime": "2017-04-13T12:32:01Z",
+      "credit": [
+        "Paul McMillan"
+      ],
+      "cves": [
+        "CVE-2014-0473"
+      ],
+      "cvssScore": 5.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "cwes": [
+        "CWE-264"
+      ],
+      "description": "## Overview\r\n[`Django`](https://pypi.python.org/pypi/Django) is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.\r\n\r\nAffected versions of this package are vulnerable to Cross-site Request Forgery (CSRF) attacks.\r\nThe caching framework reuses a cached CSRF token for all anonymous users, which allows remote attackers to bypass CSRF protections by reading the CSRF cookie for anonymous users.\r\n\r\n## Remediation\r\nUpgrade to versions `1.7b2`, `1.6.3`, `1.5.6`, `1.4.11` or greater.\r\n\r\n## References\r\n- [Django Vulnerability Description](https://www.djangoproject.com/weblog/2014/apr/21/security/)\r\n- [Redhat Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0473)\r\n- [Redhat Vulnerability Advisory](https://rhn.redhat.com/errata/RHSA-2014-0456.html)\r\n",
+      "disclosureTime": "2014-04-23T12:32:01Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-DJANGO-40026",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:46.997276Z",
+      "package": "django",
+      "patchExists": false,
+      "publicationTime": "2014-04-23T12:32:01Z",
+      "references": [
+        {
+          "title": "Django Vulnerability Description",
+          "url": "https://www.djangoproject.com/weblog/2014/apr/21/security/"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0473"
+        },
+        {
+          "title": "Redhat Vulnerability Advisory",
+          "url": "https://rhn.redhat.com/errata/RHSA-2014-0456.html"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "medium",
+      "title": "Cross-site Request Forgery (CSRF)",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-DJANGO-40026",
+      "vulnerableVersions": [
+        "[,1.4.11), [1.5,1.5.6), [1.6,1.6.3), [1.7,1.7b2)"
+      ]
+    },
+    {
+      "creationTime": "2017-04-13T12:32:00Z",
+      "credit": [
+        "Michael Koziarski"
+      ],
+      "cves": [
+        "CVE-2014-0474"
+      ],
+      "cvssScore": 9.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-399"
+      ],
+      "description": "## Overview\r\n[`Django`](https://pypi.python.org/pypi/Django) is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.\r\n\r\nAffected versions of this package are vulnerable to SQL Injection attacks.\r\nThe `FilePathField`, `GenericIPAddressField`, and `IPAddressField` model field classes in Django do not properly perform type conversion, which allows remote attackers to have unspecified impact and vectors, related to \"MySQL typecasting.\"\r\n\r\n## Remediation\r\nUpgrade to versions `1.7b2`, `1.6.3`, `1.5.6`, `1.4.11` or greater.\r\n\r\n## References\r\n- [Django Vulnerability Description](https://www.djangoproject.com/weblog/2014/apr/21/security/)\r\n- [Redhat Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0474)\r\n- [Redhat Vulnerability Advisory](https://rhn.redhat.com/errata/RHSA-2014-0456.html)\r\n",
+      "disclosureTime": "2014-04-23T12:32:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-DJANGO-40027",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:46.999639Z",
+      "package": "django",
+      "patchExists": false,
+      "publicationTime": "2014-04-23T12:32:00Z",
+      "references": [
+        {
+          "title": "Django Vulnerability Description",
+          "url": "https://www.djangoproject.com/weblog/2014/apr/21/security/"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0474"
+        },
+        {
+          "title": "Redhat Vulnerability Advisory",
+          "url": "https://rhn.redhat.com/errata/RHSA-2014-0456.html"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "high",
+      "title": "SQL Injection",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-DJANGO-40027",
+      "vulnerableVersions": [
+        "[,1.4.11), [1.5,1.5.6), [1.6,1.6.3), [1.7,1.7b2)"
+      ]
+    },
+    {
+      "creationTime": "2017-05-25T12:42:27.680000Z",
+      "credit": [
+        "Jeff Balogh"
+      ],
+      "cves": [
+        "CVE-2010-3082"
+      ],
+      "cvssScore": 4.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+      "cwes": [
+        "CWE-79"
+      ],
+      "description": "## Overview\r\n[`django`](https://pypi.python.org/pypi/django) is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.\r\n\r\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) attacks. It allows remote attackers to inject arbitrary web script or HTML via a `csrfmiddlewaretoken` (aka `csrf_token`) cookie.\r\n\r\n## Details\r\nCross-Site Scripting (XSS) attacks occur when an attacker tricks a user’s browser to execute malicious JavaScript code in the context of a victim’s domain. Such scripts can steal the user’s session cookies for the domain, scrape or modify its content, and perform or modify actions on the user’s behalf, actions typically blocked by the browser’s Same Origin Policy.\r\n\r\nThese attacks are possible by escaping the context of the web application and injecting malicious scripts in an otherwise trusted website. These scripts can introduce additional attributes (say, a \"new\" option in a dropdown list or a new link to a malicious site) and can potentially execute code on the clients side, unbeknown to the victim. This occurs when characters like `<` `>` `\"` `'` are not escaped properly.\r\n\r\nThere are a few types of XSS:\r\n- **Persistent XSS** is an attack in which the malicious code persists into the web app’s database.\r\n- **Reflected XSS** is an which the website echoes back a portion of the request. The attacker needs to trick the user into clicking a malicious link (for instance through a phishing email or malicious JS on another page), which triggers the XSS attack.\r\n- **DOM-based XSS** is an that occurs purely in the browser when client-side JavaScript echoes back a portion of the URL onto the page. DOM-Based XSS is notoriously hard to detect, as the server never gets a chance to see the attack taking place.\n\r\n\r\n## References\r\n- [Django Vulnerability Description](http://www.djangoproject.com/weblog/2010/sep/08/security-release/)\r\n- [Redhat Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=632239)\r\n- [CVE](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2010-3082)\r\n",
+      "disclosureTime": "2010-09-09T09:18:41.580000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-DJANGO-40053",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:46.091134Z",
+      "package": "django",
+      "patchExists": false,
+      "publicationTime": "2010-09-09T09:18:41.580000Z",
+      "references": [
+        {
+          "title": "Django Vulnerability Description",
+          "url": "http://www.djangoproject.com/weblog/2010/sep/08/security-release/"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=632239"
+        },
+        {
+          "title": "CVE",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2010-3082"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-DJANGO-40053",
+      "vulnerableVersions": [
+        "[1.2,1.2.2)"
+      ]
+    },
+    {
+      "creationTime": "2017-05-25T12:42:27.683000Z",
+      "credit": [
+        "Adam Baldwin"
+      ],
+      "cves": [
+        "CVE-2010-4534"
+      ],
+      "cvssScore": 4.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+      "cwes": [
+        "CWE-264"
+      ],
+      "description": "## Overview\r\n[`django`](https://pypi.python.org/pypi/django) is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.\r\n\r\nAffected versions of this package expose sensitive information due to not properly restricting the use of a query string that performs certain object filtering. An attacker may obtain sensitive information via a series of requests containing regular expressions, as demonstrated by a `created_by__password__regex` parameter.\r\n\r\n## References\r\n- [Django Vulnerability Description](http://www.djangoproject.com/weblog/2010/dec/22/security/)\r\n- [GitHub Commit](https://github.com/django/django/commit/732198ed5c)\r\n- [Redhat Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=665373)\r\n- [Openwall](http://www.openwall.com/lists/oss-security/2011/01/03/5)\r\n- [CVE](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2010-4534)\r\n",
+      "disclosureTime": "2010-12-22T07:57:39.832000Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-DJANGO-40055",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-18T11:50:46.094932Z",
+      "package": "django",
+      "patchExists": false,
+      "publicationTime": "2010-12-22T07:57:39.832000Z",
+      "references": [
+        {
+          "title": "Django Vulnerability Description",
+          "url": "http://www.djangoproject.com/weblog/2010/dec/22/security/"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/django/django/commit/732198ed5c"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=665373"
+        },
+        {
+          "title": "Openwall",
+          "url": "http://www.openwall.com/lists/oss-security/2011/01/03/5"
+        },
+        {
+          "title": "CVE",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2010-4534"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "medium",
+      "title": "Information Exposure",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-DJANGO-40055",
+      "vulnerableVersions": [
+        "[,1.1.3), [1.2,1.2.4)"
+      ]
+    },
+    {
+      "creationTime": "2018-01-18T07:37:51.763000Z",
+      "credit": [
+        "Hunter2.com"
+      ],
+      "cves": [
+        "CVE-2018-5773"
+      ],
+      "cvssScore": 6.1,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+      "cwes": [
+        "CWE-79"
+      ],
+      "description": "## Overview\r\n[`markdown2`](http://pypi.python.org/pypi/markdown2) is A fast and complete Python implementation of Markdown.\r\n\r\nAffected versions of the package are vulnerable to Cross-site Scripting (XSS) attacks via the `safe_mode` feature, which is supposed to sanitize user input against XSS. With a crafted payload, XSS can be triggered, as demonstrated by omitting the final '>' character from an IMG tag.\r\n\r\n### PoC by Vineet Kumar\r\n```py\r\n>>> from markdown2 import markdown as mark\r\n>>> mark('<img src=\"\" onerror=alert(/XSS/)>', safe_mode=True)\r\nu'<p>[HTML_REMOVED]</p>\\n'\r\n>>> mark('<img src=\"\" onerror=alert(/XSS/) ', safe_mode=True) # Please notice the space at end of string.\r\nu'<p><img src=\"\" onerror=alert(/XSS/) </p>\\n'\r\n>>> mark('<img src=\"\" onerror=alert(/XSS/)>', safe_mode=\"escape\")\r\nu'<p>&lt;img src=\"\" onerror=alert(/XSS/)&gt;</p>\\n'\r\n>>> mark('<img src=\"\" onerror=alert(/XSS/) ', safe_mode=\"escape\")\r\nu'<p><img src=\"\" onerror=alert(/XSS/) </p>\\n'\r\n```\r\n\r\n## Details\r\nCross-Site Scripting (XSS) attacks occur when an attacker tricks a user’s browser to execute malicious JavaScript code in the context of a victim’s domain. Such scripts can steal the user’s session cookies for the domain, scrape or modify its content, and perform or modify actions on the user’s behalf, actions typically blocked by the browser’s Same Origin Policy.\r\n\r\nThese attacks are possible by escaping the context of the web application and injecting malicious scripts in an otherwise trusted website. These scripts can introduce additional attributes (say, a \"new\" option in a dropdown list or a new link to a malicious site) and can potentially execute code on the clients side, unbeknown to the victim. This occurs when characters like `<` `>` `\"` `'` are not escaped properly.\r\n\r\nThere are a few types of XSS:\r\n- **Persistent XSS** is an attack in which the malicious code persists into the web app’s database.\r\n- **Reflected XSS** is an which the website echoes back a portion of the request. The attacker needs to trick the user into clicking a malicious link (for instance through a phishing email or malicious JS on another page), which triggers the XSS attack.\r\n- **DOM-based XSS** is an that occurs purely in the browser when client-side JavaScript echoes back a portion of the URL onto the page. DOM-Based XSS is notoriously hard to detect, as the server never gets a chance to see the attack taking place.\r\n\r\n## Remediation\r\nUpgrade `markdown2` to version 2.3.7 or higher.\n\n## References\n- [GitHub Commit #1](https://github.com/trentm/python-markdown2/commit/1b1dcdd727c0ef03453b9f5ef5ae3679f1d72323)\n- [GitHub Commit #2](https://github.com/trentm/python-markdown2/commit/1fb702d650d35f7a6fee7f8dbe819e53ceaff53e)\n- [GitHub Issue](https://github.com/trentm/python-markdown2/issues/285)\n- [Github PR](https://github.com/trentm/python-markdown2/pull/315)\n",
+      "disclosureTime": "2018-01-17T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-MARKDOWN2-40770",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-02-06T08:03:07.873076Z",
+      "package": "markdown2",
+      "patchExists": false,
+      "publicationTime": "2018-01-19T09:38:48Z",
+      "references": [
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/trentm/python-markdown2/issues/285"
+        },
+        {
+          "title": "GitHub Commit #1",
+          "url": "https://github.com/trentm/python-markdown2/commit/1b1dcdd727c0ef03453b9f5ef5ae3679f1d72323"
+        },
+        {
+          "title": "Github PR",
+          "url": "https://github.com/trentm/python-markdown2/pull/315"
+        },
+        {
+          "title": "GitHub Commit #2",
+          "url": "https://github.com/trentm/python-markdown2/commit/1fb702d650d35f7a6fee7f8dbe819e53ceaff53e"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-MARKDOWN2-40770",
+      "vulnerableVersions": [
+        "[,2.3.7)"
+      ]
+    },
+    {
+      "creationTime": "2017-08-08T06:59:14.640000Z",
+      "credit": [
+        "Maor Shwartz"
+      ],
+      "cves": [
+        "CVE-2017-11610"
+      ],
+      "cvssScore": 8.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\n[`supervisor`](https://pypi.python.org/pypi/supervisor/) is a client/server system that allows its users to monitor and control a number of processes on UNIX-like operating systems.\n\nAffected versions of the package are vulnerable to Arbitrary Command Execution. A vulnerability has been found where an authenticated client can send a malicious XML-RPC request to `supervisord` that will run arbitrary shell commands on the server. The commands will be run as the same user as `supervisord`. Depending on how `supervisord` has been configured, this may be root.\n\n## Details\n* `supervisord` is the server component and is responsible for starting child processes, responding to commands from clients, and other commands.\n* `supervisorctl` is the command line component, providing a shell-like interface to the features provided by `supervisord`.\n\n`supervisord` can be configured to run an HTTP server on a TCP socket and/or a Unix domain socket. This HTTP server is how `supervisorctl` communicates with `supervisord`. If an HTTP server has been enabled, it will always serve both HTML pages and an XML-RPC interface. A vulnerability has been found where an authenticated client can send a malicious XML-RPC request to `supervisord` that will run arbitrary shell commands on the server. The commands will be run as the same user as `supervisord`. Depending on how `supervisord` has been configured, this may be root.\nThis vulnerability can only be exploited by an authenticated client or if `supervisord` has been configured to run an HTTP server without authentication. If authentication has not been enabled, `supervisord` will log a message at the critical level every time it starts.\n\n## PoC by Maor Shwartz\n\nCreate a config file `supervisord.conf`:\n\n```conf\n[supervisord]\nloglevel = trace\n\n[inet_http_server]\nport = 127.0.0.1:9001\n\n[rpcinterface:supervisor]\nsupervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface\n```\n\nStart supervisord in the foreground with that config file:\n\n```\n$ supervisord -n -c supervisord.conf\n```\n\nIn a new terminal:\n\n```py\n$ python2\n>>> from xmlrpclib import ServerProxy\n>>> server = ServerProxy('http://127.0.0.1:9001/RPC2')\n>>> server.supervisor.supervisord.options.execve('/bin/sh', [], {})\n  ```\n\nIf the `supervisord` version is vulnerable, the `execve` will be executed and the `supervisord` process will be replaced with /bin/sh (or any other command given). If the `supervisord` version is not vulnerable, it will return an `UNKNOWN_METHOD` fault.\n\n\n## Remediation\nUpgrade `supervisor` to version 3.3.3 or higher.\n\n## References\n- [Github Issue](https://github.com/Supervisor/supervisor/issues/964)\n- [Github Commit 3.0.1](https://github.com/Supervisor/supervisor/commit/83060f3383ebd26add094398174f1de34cf7b7f0)\n- [Github Commit 3.1.4](https://github.com/Supervisor/supervisor/commit/dbe0f55871a122eac75760aef511efc3a8830b88)\n- [Github Commit 3.2.4](https://github.com/Supervisor/supervisor/commit/aac3c21893cab7361f5c35c8e20341b298f6462e)\n- [Github Commit 3.3.3](https://github.com/Supervisor/supervisor/commit/058f46141e346b18dee0497ba11203cb81ecb19e)\n",
+      "disclosureTime": "2017-07-18T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-PYTHON-SUPERVISOR-40610",
+      "language": "python",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2019-02-06T08:03:07.857298Z",
+      "package": "supervisor",
+      "patchExists": false,
+      "publicationTime": "2017-08-08T06:59:14.640000Z",
+      "references": [
+        {
+          "title": "Github Issue",
+          "url": "https://github.com/Supervisor/supervisor/issues/964"
+        },
+        {
+          "title": "Github Commit 3.0.1",
+          "url": "https://github.com/Supervisor/supervisor/commit/83060f3383ebd26add094398174f1de34cf7b7f0"
+        },
+        {
+          "title": "Github Commit 3.1.4",
+          "url": "https://github.com/Supervisor/supervisor/commit/dbe0f55871a122eac75760aef511efc3a8830b88"
+        },
+        {
+          "title": "Github Commit 3.2.4",
+          "url": "https://github.com/Supervisor/supervisor/commit/aac3c21893cab7361f5c35c8e20341b298f6462e"
+        },
+        {
+          "title": "Github Commit 3.3.3",
+          "url": "https://github.com/Supervisor/supervisor/commit/058f46141e346b18dee0497ba11203cb81ecb19e"
+        }
+      ],
+      "registry": "pypi.org",
+      "severity": "high",
+      "title": "Arbitrary Command Execution",
+      "url": "https://snyk.io/vuln/SNYK-PYTHON-SUPERVISOR-40610",
+      "vulnerableVersions": [
+        "[3.0a1,3.0.1), [3.1,3.1.4), [3.2,3.2.4), [3.3,3.3.3)"
+      ]
+    }
+  ],
+  "ruby": [
+    {
+      "creationTime": "2016-09-21T12:36:39Z",
+      "credit": [
+        "Daniel Waterworth"
+      ],
+      "cves": [
+        "CVE-2015-7576"
+      ],
+      "cvssScore": 3.7,
+      "cvssV3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "cwes": [
+        "CWE-208"
+      ],
+      "description": "## Overview\n[`actionpack`](https://rubygems.org/gems/actionpack) is a web app builder and tester on Rails.\n\nAffected versions of this Gem are vulnerable to a Timing Attack, via the basic authentication support in Action Controller. This can allow an attacker to determine basic authentication usernames and passwords.\n\n## Details\nDue to the way that Action Controller compares user names and passwords in basic authentication authorization code, it is possible for an attacker to analyze the time taken by a response and guess the password.\n\nFor example, the string comparison `\"foo\" == \"far\"` is possibly faster than the comparison `\"foo\" == \"for\"`, as `\"far\"` has fewer characters in common with `\"foo\"`.\nAttackers can use this information to attempt to guess the username and password used in the basic authentication system, one character at a time.\n\nYou can tell your application is vulnerable to this attack by looking for `http_basic_authenticate_with` method calls in your application.\n\nYou can read more about timing attacks (using Node.js as an example) on the Snyk blog: [https://snyk.io/blog/node-js-timing-attack-ccc-ctf/](https://snyk.io/blog/node-js-timing-attack-ccc-ctf/)\n\n## References\n- [Rubysec Security Advisory](http://rubysec.com/advisories/actionpack-CVE-2015-7576)\n- [Google Forum](https://groups.google.com/forum/#!topic/rubyonrails-security/ANv0HDHEC3k)\n",
+      "disclosureTime": "2016-01-24T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-RUBY-ACTIONPACK-20258",
+      "language": "ruby",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:11.484756Z",
+      "package": "actionpack",
+      "patchExists": false,
+      "publicationTime": "2016-01-24T22:00:00Z",
+      "references": [
+        {
+          "title": "Rubysec Security Advisory",
+          "url": "http://rubysec.com/advisories/actionpack-CVE-2015-7576"
+        },
+        {
+          "title": "Google Forum",
+          "url": "https://groups.google.com/forum/#!topic/rubyonrails-security/ANv0HDHEC3k"
+        }
+      ],
+      "registry": "rubygems.org",
+      "severity": "low",
+      "title": "Timing Attack",
+      "url": "https://snyk.io/vuln/SNYK-RUBY-ACTIONPACK-20258",
+      "vulnerableVersions": [
+        "< 5.0.0.beta1.1, >= 4.3",
+        "< 4.2.5.1, >= 4.2",
+        "< 4.1.14.1, >= 3.2.23",
+        "< 3.2.22.1"
+      ]
+    },
+    {
+      "creationTime": "2016-09-21T12:36:39Z",
+      "credit": [
+        "Tobias Kraze",
+        "joernchen"
+      ],
+      "cves": [
+        "CVE-2016-2098"
+      ],
+      "cvssScore": 7.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "cwes": [
+        "CWE-94"
+      ],
+      "description": "## Overview\n[`actionpack`](https://rubygems.org/gems/actionpack) is a web app builder and tester on Rails.\nAffected versions of this Gem are vulnerable to Arbitrary Code Injection.\n\n## Details\nApplications that pass unverified user input to the `render` method in a\ncontroller or a view may be vulnerable to a code injection.\n\nImpacted code will look like this:\n\n```ruby\nclass TestController < ApplicationController\n  def show\n    render params[:id]\n  end\nend\n```\n\nAn attacker could use the request parameters to coerce the above example\nto execute arbitrary ruby code.\n\nAll users running an affected release should either upgrade or use one of\nthe workarounds immediately.\n\n## References\n- [Rubysec Security Advisory](http://rubysec.com/advisories/CVE-2016-2098)\n- [Google Forum](https://groups.google.com/forum/#!topic/rubyonrails-security/ly-IH-fxr_Q)\n",
+      "disclosureTime": "2016-02-28T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-RUBY-ACTIONPACK-20264",
+      "language": "ruby",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:11.548085Z",
+      "package": "actionpack",
+      "patchExists": false,
+      "publicationTime": "2016-02-28T22:00:00Z",
+      "references": [
+        {
+          "title": "Rubysec Security Advisory",
+          "url": "http://rubysec.com/advisories/CVE-2016-2098"
+        },
+        {
+          "title": "Google Forum",
+          "url": "https://groups.google.com/forum/#!topic/rubyonrails-security/ly-IH-fxr_Q"
+        }
+      ],
+      "registry": "rubygems.org",
+      "severity": "high",
+      "title": "Arbitrary Code Injection",
+      "url": "https://snyk.io/vuln/SNYK-RUBY-ACTIONPACK-20264",
+      "vulnerableVersions": [
+        "< 5.0.0.beta1, >= 4.3",
+        "< 4.2.5.2, >= 4.2",
+        "< 4.1.14.2, >= 3.2.23",
+        "< 3.2.22.2"
+      ]
+    },
+    {
+      "creationTime": "2016-09-21T12:36:44Z",
+      "credit": [
+        "Francois Chagnon"
+      ],
+      "cves": [
+        "CVE-2015-3226"
+      ],
+      "cvssScore": 4.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+      "cwes": [
+        "CWE-79"
+      ],
+      "description": "## Overview\n\n[`activesupport`](https://rubygems.org/gems/activesupport) is toolkit of support libraries and Ruby core extensions extracted from the Rails framework\n\nRails does not perform adequate escaping when a `Hash` containing user-controlled data is encoded as JSON\n\nWhen a `Hash` containing user-controlled data is encoded as JSON (either through `Hash#to_json` or `ActiveSupport::JSON.encode`), Rails does not perform adequate escaping that matches the guarantee implied by the `escape_html_entities_in_json` option (which is enabled by default). If this resulting JSON string is subsequently inserted directly into an HTML page, the page will be vulnerable to XSS attacks.\n\nFor example, the following code snippet is vulnerable to this attack:\n\n    <%= javascript_tag \"var data = #{user_supplied_data.to_json};\" %>\n\nSimilarly, the following is also vulnerable:\n\n    <script>\n      var data = <%= ActiveSupport::JSON.encode(user_supplied_data).html_safe %>;\n    </script>\n\nAll applications that renders JSON-encoded strings that contains user-controlled data in their views should either upgrade to one of the FIXED versions or use the suggested workaround immediately.\n\n## Details\nCross-Site Scripting (XSS) attacks occur when an attacker tricks a user’s browser to execute malicious JavaScript code in the context of a victim’s domain. Such scripts can steal the user’s session cookies for the domain, scrape or modify its content, and perform or modify actions on the user’s behalf, actions typically blocked by the browser’s Same Origin Policy.\r\n\r\nThese attacks are possible by escaping the context of the web application and injecting malicious scripts in an otherwise trusted website. These scripts can introduce additional attributes (say, a \"new\" option in a dropdown list or a new link to a malicious site) and can potentially execute code on the clients side, unbeknown to the victim. This occurs when characters like `<` `>` `\"` `'` are not escaped properly.\r\n\r\nThere are a few types of XSS:\r\n- **Persistent XSS** is an attack in which the malicious code persists into the web app’s database.\r\n- **Reflected XSS** is an which the website echoes back a portion of the request. The attacker needs to trick the user into clicking a malicious link (for instance through a phishing email or malicious JS on another page), which triggers the XSS attack.\r\n- **DOM-based XSS** is an that occurs purely in the browser when client-side JavaScript echoes back a portion of the URL onto the page. DOM-Based XSS is notoriously hard to detect, as the server never gets a chance to see the attack taking place.\n\n\n## References\n- http://rubysec.com/advisories/CVE-2015-3226\n- https://groups.google.com/forum/#!topic/ruby-security-ann/7VlB_pck3hU\n",
+      "disclosureTime": "2015-06-15T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-RUBY-ACTIVESUPPORT-20228",
+      "language": "ruby",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:11.435571Z",
+      "package": "activesupport",
+      "patchExists": false,
+      "publicationTime": "2015-06-15T21:00:00Z",
+      "references": [
+        {
+          "title": "RUBYSEC.COM",
+          "url": "http://rubysec.com/advisories/CVE-2015-3226"
+        },
+        {
+          "title": "GROUPS.GOOGLE.COM",
+          "url": "https://groups.google.com/forum/#!topic/ruby-security-ann/7VlB_pck3hU"
+        }
+      ],
+      "registry": "rubygems.org",
+      "severity": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "url": "https://snyk.io/vuln/SNYK-RUBY-ACTIVESUPPORT-20228",
+      "vulnerableVersions": [
+        "< 4.2.2, >= 4.2",
+        "< 4.1.11, >= 4.1.0"
+      ]
+    },
+    {
+      "creationTime": "2016-09-21T12:36:44Z",
+      "credit": [
+        "Tomek Rabczak"
+      ],
+      "cves": [
+        "CVE-2015-3227"
+      ],
+      "cvssScore": 5.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "cwes": [
+        "CWE-400"
+      ],
+      "description": "## Overview\n[`activesupport`](https://rubygems.org/gems/activesupport) is toolkit of support libraries and Ruby core extensions extracted from the Rails framework.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). Specially crafted XML documents can cause applications to raise a `SystemStackError`. This only impacts applications using REXML or JDOM as their XML processor. Other XML processors that Rails supports are not impacted.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `activesupport` to versions 4.1.11, 4.2.2, 4.2.22 or higher.\n\n## References\n- [Rubysec Security Advisory](https://rubysec.com/advisories/activesupport-CVE-2015-3227)\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2015-3227)\n",
+      "disclosureTime": "2015-06-15T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-RUBY-ACTIVESUPPORT-20229",
+      "language": "ruby",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:08.179779Z",
+      "package": "activesupport",
+      "patchExists": false,
+      "publicationTime": "2015-06-15T21:00:00Z",
+      "references": [
+        {
+          "title": "Rubysec Security Advisory",
+          "url": "https://rubysec.com/advisories/activesupport-CVE-2015-3227"
+        },
+        {
+          "title": "NVD",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-3227"
+        }
+      ],
+      "registry": "rubygems.org",
+      "severity": "medium",
+      "title": "Denial of Service (DoS)",
+      "url": "https://snyk.io/vuln/SNYK-RUBY-ACTIVESUPPORT-20229",
+      "vulnerableVersions": [
+        "< 4.2.2, >= 4.2",
+        "< 4.1.11, >= 3.3",
+        "< 3.2.22"
+      ]
+    },
+    {
+      "creationTime": "2017-01-12T12:37:00Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cves": [],
+      "cvssScore": 7.3,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "cwes": [
+        "CWE-611"
+      ],
+      "description": "## Overview\n[nokogiri](https://rubygems.org/gems/nokogiri) is an HTML, XML, SAX, and Reader parser, with the ability to search documents via XPath or CSS3 selectors.\n\nAffected versions of this Gem are vulnerable to XML External Entity (XXE) attacks when opting into the `DTDLOAD` option and opting out of the `NONET` option.\n`Nokogiri` is affected by series of vulnerabilities in libxml2 and libxslt, which are libraries it depends on. When handling the expansion of XML external entities (XXE) in libxml2, you can specify documents to be read. Opting into the `DTDLOAD` option and opting out of the `NONET` option in `Nokogiri` allows unknown documents to be loaded from the network. This can be used by attackers to load specially crafted XML documents on an internal XML parsing service and may lead to unauthorized disclosure of potentially sensitive information.\n\n**Note:** This vulnerability exists also in versions `< 1.5.4` regardless of the options opted into or out of. See information [here](https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-20298)\n\n## Details\n\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nNokogiri suggests not to opt-out of `NONET` unless only trusted documents are being parsed.\nThere currently is no fix in libxml2 as of September 17th, 2017.\n`Nokogiri` will be waiting for a fix upstream to update.\n\n## Disclosure Timeline\n- January 11th, 2017 - Reported the issue to [Mike Dalessio](https://github.com/flavorjones) of Nokogiri Core.\n- January 11th, 2017 - Issue triaged and acknowledged by [Mike Dalessio](https://github.com/flavorjones) of Nokogiri Core.\n\n## References\n- [GitHub Issue](https://github.com/sparklemotion/nokogiri/issues/1582)\n- [CVE-2016-9318](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9318)\n",
+      "disclosureTime": "2017-01-11T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": false,
+      "id": "SNYK-RUBY-NOKOGIRI-20299",
+      "language": "ruby",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:06.539065Z",
+      "package": "nokogiri",
+      "patchExists": false,
+      "publicationTime": "2017-01-16T21:00:00Z",
+      "references": [
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/sparklemotion/nokogiri/issues/1582"
+        },
+        {
+          "title": "CVE-2016-9318",
+          "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9318"
+        }
+      ],
+      "registry": "rubygems.org",
+      "severity": "high",
+      "title": "XML External Entity (XXE) Injection",
+      "url": "https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-20299",
+      "vulnerableVersions": [
+        ">= 1.5.4"
+      ]
+    },
+    {
+      "creationTime": "2017-05-15T06:31:03.597000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cves": [
+        "CVE-2017-5029"
+      ],
+      "cvssScore": 8.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-787"
+      ],
+      "description": "## Overview\n[`nokogiri`](https://rubygems.org/gems/nokogiri) (鋸) is an HTML, XML, SAX, and Reader parser, with the ability to search documents via XPath or CSS3 selectors.\n\nAffected versions of the package are vulnerable to Out of Bounds Memory Write. Nokogiri bundles  the `libxslt` library, which is vulnerable in versions below 3. The `xsltAddTextString` function in `transform.c` lacked a check for integer overflow during a size calculation, which allowed a remote attacker to perform an out of bounds memory write via a crafted HTML page.\n\n## Remediation\nUpgrade `nokogiri` to version 1.7.2 or higher.\n\n## References\n- [GitHub Issue](https://github.com/sparklemotion/nokogiri/issues/1634)\n- [GitHub Commit](https://github.com/sparklemotion/nokogiri/commit/0859c487c9f6933d96d998560d88147c841f7336)\n",
+      "disclosureTime": "2017-04-28T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-RUBY-NOKOGIRI-20368",
+      "language": "ruby",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:06.867797Z",
+      "package": "nokogiri",
+      "patchExists": false,
+      "publicationTime": "2017-05-15T06:31:03.597000Z",
+      "references": [
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/sparklemotion/nokogiri/issues/1634"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/sparklemotion/nokogiri/commit/0859c487c9f6933d96d998560d88147c841f7336"
+        }
+      ],
+      "registry": "rubygems.org",
+      "severity": "high",
+      "title": "Out of Bounds Memory Write",
+      "url": "https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-20368",
+      "vulnerableVersions": [
+        "<1.7.2"
+      ]
+    },
+    {
+      "creationTime": "2017-09-18T06:31:03.597000Z",
+      "credit": [
+        "Marcel Böhme",
+        "Van-Thuan Pham"
+      ],
+      "cves": [
+        "CVE-2017-0663",
+        "CVE-2017-7375",
+        "CVE-2017-7376",
+        "CVE-2017-9047",
+        "CVE-2017-9048",
+        "CVE-2017-9049",
+        "CVE-2017-9050"
+      ],
+      "cvssScore": 9.8,
+      "cvssV3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "cwes": [
+        "CWE-126",
+        "CWE-200",
+        "CWE-399",
+        "CWE-89"
+      ],
+      "description": "## Overview\n[`nokogiri`](https://rubygems.org/gems/nokogiri) (鋸) is an HTML, XML, SAX, and Reader parser, with the ability to search documents via XPath or CSS3 selectors.\n\nAffected versions of the package are vulnerable to many vulnerabilities, including Arbitrary Code Execution and Denial of Service (DoS), and Sensitive Information Exposure. Nokogiri bundles the `libxml2` library, which is vulnerable in versions below 2.9.5.\n\nThe CVEs assigned to the vulnerabilities are:\n\n### CVE-2017-0663\n> It was discovered that a type confusion error existed in libxml2. An attacker could use this to specially construct XML data that could cause a denial of service or possibly execute arbitrary code.\n\n### CVE-2017-7375\n> It was discovered that libxml2 did not properly validate parsed entity references. An attacker could use this to specially construct XML data that could expose sensitive information.\n\n### CVE-2017-7376\n> It was discovered that a buffer overflow existed in libxml2 when handling HTTP redirects. An attacker could use this to specially construct XML data that could cause a denial of service or possibly execute arbitrary code.\n\n### CVE-2017-9047\n> Marcel Böhme and Van-Thuan Pham discovered a buffer overflow in libxml2 when handling elements. An attacker could use this to specially construct XML data that could cause a denial of service or possibly execute arbitrary code.\n\n### CVE-2017-9048\n> Marcel Böhme and Van-Thuan Pham discovered a buffer overread in libxml2 when handling elements. An attacker could use this to specially construct XML data that could cause a denial of service.\n\n### CVE-2017-9049, CVE-2017-9050\n> Marcel Böhme and Van-Thuan Pham discovered multiple buffer overreads in libxml2 when handling parameter-entity references. An attacker could use these to specially construct XML data that could cause a denial of service.\n\n## Remediation\nUpgrade `nokogiri` to version 1.8.1 or higher.\n\n## References\n- [GitHub Issue](https://github.com/sparklemotion/nokogiri/issues/1673)\n- [Ubuntu Security Notice](https://usn.ubuntu.com/usn/usn-3424-1/)\n",
+      "disclosureTime": "2017-09-18T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixable": true,
+      "id": "SNYK-RUBY-NOKOGIRI-20432",
+      "language": "ruby",
+      "malicious": false,
+      "methods": [],
+      "modificationTime": "2018-11-22T10:10:06.828244Z",
+      "package": "nokogiri",
+      "patchExists": false,
+      "publicationTime": "2017-09-21T13:31:03.597000Z",
+      "references": [
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/sparklemotion/nokogiri/issues/1673"
+        },
+        {
+          "title": "Ubuntu Security Notice",
+          "url": "https://usn.ubuntu.com/usn/usn-3424-1/"
+        }
+      ],
+      "registry": "rubygems.org",
+      "severity": "high",
+      "title": "Use of vulnerable libxml2",
+      "url": "https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-20432",
+      "vulnerableVersions": [
+        "<1.8.1"
+      ]
+    }
+  ]
+}

--- a/graph_snyk_cve_sync.py
+++ b/graph_snyk_cve_sync.py
@@ -18,117 +18,21 @@
 """Script which synchronizes snyk CVEs from S3 to graph."""
 
 from datetime import datetime, timedelta
-import boto3
 import json
 import os
 from f8a_utils.versions import get_versions_and_latest_for_ep
 from f8a_utils.golang_utils import GolangUtils
 from unified_range import api
 from f8a_version_comparator.comparable_version import ComparableVersion
+from helper import Helper
 import re
 import logging
-import requests
 import time
 
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 SUPPORTED_ECOSYSTEMS = ['maven', 'npm', 'pypi', 'golang']
-
-
-class Helper:
-    """Helper class with some utility functions."""
-
-    def __init__(self):
-        """Init method for helper class."""
-        self.CVE_BUCKET = os.environ.get("REPORT_BUCKET_NAME", '')
-        self.AWS_KEY = os.environ.get("AWS_S3_ACCESS_KEY_ID_REPORT_BUCKET", '')
-        self.AWS_SECRET = os.environ.get("AWS_S3_SECRET_ACCESS_KEY_REPORT_BUCKET", '')
-        self.AWS_REGION = os.environ.get("AWS_S3_REGION", "us-east-1")
-        self.HOST = os.environ.get('BAYESIAN_DATA_IMPORTER_SERVICE_HOST', 'bayesian-data-importer')
-        self.PORT = os.environ.get('BAYESIAN_DATA_IMPORTER_SERVICE_PORT', '9192')
-
-        self.s3_resource = boto3.resource('s3', aws_access_key_id=self.AWS_KEY,
-                                          aws_secret_access_key=self.AWS_SECRET,
-                                          region_name=self.AWS_REGION)
-
-    def store_json_content(self, content, obj_key):
-        """Store the report content to the S3 storage."""
-        try:
-            logger.info('Storing the data into the S3 file %s' % obj_key)
-            self.s3_resource.Object(self.CVE_BUCKET, obj_key).put(
-                Body=json.dumps(content, indent=2).encode('utf-8'))
-        except Exception as e:
-            logger.exception('%r' % e)
-
-    def _retrieve_dict(self, object_key):
-        """Retrieve a dictionary stored as JSON from S3."""
-        return json.loads(self._retrieve_blob(object_key).decode('utf-8'))
-
-    def _retrieve_blob(self, object_key):
-        """Retrieve remote object content."""
-        return self.s3_resource.Object(self.CVE_BUCKET, object_key).get()['Body'].read()
-
-    def read_data_from_s3(self, date, loc):
-        """Read the snyk data from S3."""
-        try:
-            filename = loc + date + ".json"
-            logger.info('Retrieving the data from the S3 file %s' % filename)
-            return self._retrieve_dict(filename)
-        except Exception as e:
-            logger.error(e)
-            return False
-
-    def make_api_call(self, payload, mode):
-        """Make an API call to data importer."""
-        try:
-            api_url = "http://" + self.HOST + ":" + self.PORT
-            headers = {'Content-type': 'application/json'}
-            msg = ""
-            response = ""
-            if mode == "PUT":
-                response = requests.put('{}/api/v1/snyk-cves'.format(api_url), headers=headers,
-                                        data=json.dumps(payload))
-                msg = "ingested"
-                key = payload['package']
-            elif mode == "DELETE":
-                response = requests.delete('{}/api/v1/snyk-cves'.format(api_url), headers=headers,
-                                           data=json.dumps(payload))
-                msg = "deleted"
-                key = payload['id']
-            if response.status_code == 200:
-                logger.info("CVEs for {p} successfully {m}".format(p=key, m=msg))
-                return "success"
-            elif response.status_code == 504:
-                logger.info("Operation for {p} is taking time. "
-                            "Will be {m} in the background".format(p=key, m=msg))
-                return "delayed"
-            else:
-                logger.info("Error while {m} CVEs for {p}".format(p=key, m=msg))
-                logger.info("Status Code {}".format(response.status_code))
-            return "failed"
-        except Exception:
-            logger.error("API call to data importer failed.")
-
-    def is_dry_run(self):
-        """Return True if this is a dry run."""
-        # Set this value to true if you want the entire operation to run, but not the ingestion.
-        return os.environ.get('SNYK_DRY_RUN', 'false').lower() in ('1', 'yes', 'true')
-
-    def force_run_ingestion(self):
-        """Return if ingestion mode is on."""
-        # Set this value when you want to run the ingestion forcefully (ignores runtime).
-        return os.environ.get('SNYK_INGESTION_FORCE_RUN', 'false').lower() in ('1', 'yes', 'true')
-
-    def is_delta_mode_on(self):
-        """Return if the delta feed mode is on."""
-        # Set this value if you want to run only in the diff mode.
-        return os.environ.get('SNYK_DELTA_FEED_MODE', 'false').lower() in ('1', 'yes', 'true')
-
-    def ingestion_run_time(self):
-        """Return the time when ingestion needs to run."""
-        # Set the time at which you want the ingestion to run.
-        return os.environ.get('SNYK_INGESTION_RUN_TIME', '12')
 
 
 class SnykCveSync:
@@ -147,7 +51,6 @@ class SnykCveSync:
         # This is the offset days i.e how many days old data do we need to ingest.
         delta_feed_offset = int(os.environ.get('SNYK_DELTA_FEED_OFFSET', '1'))
         self.start_day = self.today - timedelta(days=delta_feed_offset)
-        self.selective_eco_run = os.environ.get('SELECTIVE_ECOSYSTEM_SNYK_SYNC', 'none')
 
         # If we want to selectively run the ingestion for an ecosystem.
         self.selective_eco_run = os.environ.get('SELECTIVE_ECOSYSTEM_SNYK_SYNC', '')
@@ -277,15 +180,19 @@ class SnykCveSync:
         for eco in self.snyk_data:
             if eco == "java" and self._parse_data_for_eco(eco):
                 logger.info("Parsing feed for Maven.")
+                self._add_default_obj_for_eco("maven")
                 self._parse_data(self.snyk_data[eco], "maven")
             elif eco == "js" and self._parse_data_for_eco(eco):
                 logger.info("Parsing feed for Npm.")
+                self._add_default_obj_for_eco("npm")
                 self._parse_data(self.snyk_data[eco], "npm")
             elif eco == "python" and self._parse_data_for_eco(eco):
                 logger.info("Parsing feed for Pypi.")
+                self._add_default_obj_for_eco("pypi")
                 self._parse_data(self.snyk_data[eco], "pypi")
             elif eco == "golang" and self._parse_data_for_eco(eco):
                 logger.info("Parsing feed for Golang.")
+                self._add_default_obj_for_eco("golang")
                 self._parse_golang_data(self.snyk_data[eco], "golang")
             else:
                 logger.info("Ignoring the ecosystem {} from the feed".format(eco))
@@ -296,6 +203,22 @@ class SnykCveSync:
         """When running under delta feed mode, we need to consider only those vulns which were
         updated between the given offset date and today's date."""
         return self.today > date_obj >= self.start_day
+
+    def _add_default_obj_for_eco(self, eco):
+        """Add default entries for the ecosystem into the different lists."""
+        self.CVE_DATA[eco] = {}
+        self.DELETE_CVE_DATA[eco] = []
+        self.DELTA_FEED[eco] = []
+
+    def _add_data_for_false_positives(self, eco, data, pkg):
+        """Update the records with false positive data."""
+        self.DELETE_CVE_DATA[eco].append(data)
+        self.DELTA_FEED[eco].append(data)
+        # Default status is skipped. When ingested, it gets updated with success or failed.
+        self.SNYK_REPORT['details'][eco]['delete'][data['id']] = {
+            'name': pkg,
+            'status': "skipped"
+        }
 
     def _generate_default_cve_obj(self, eco, pkg, versions, latest, gh=None, lic=None):
         """Generate the default cve object."""
@@ -319,14 +242,22 @@ class SnykCveSync:
             obj['license'] = lic
         return obj
 
+    def _set_additional_fields(self, data):
+        """To set additional fields or modify some values before ingesting."""
+        # Remove the non required rules data.
+        del data['rules']
+        # Change description into proper string.
+        data['description'] = re.sub("[\'\"]", "", data['description'])
+        # Calculate and update the premium field.
+        premium = str(data.get('premium', "false")).lower() == 'true'
+        data['pvtVuln'] = premium
+        return data
+
     def _parse_golang_data(self, vuln_data, eco):
         """Parse data for golang eco."""
         total_vuln = 0
         delta_mode = self.helper.is_delta_mode_on()
         if len(vuln_data) != 0:
-            self.CVE_DATA[eco] = {}
-            self.DELETE_CVE_DATA[eco] = []
-            self.DELTA_FEED[eco] = []
             for data in vuln_data:
                 # If delta mode is on & the modificationTime doesnt fall in the range, then ignore.
                 if delta_mode and not self._is_date_in_range(data['modificationTime']):
@@ -338,12 +269,7 @@ class SnykCveSync:
                     if len(data['vulnerableVersions']) == 0:
                         # In this case, we use the data to remove the vuln from the garph
                         logger.info("False positive found. {i}".format(i=data['id']))
-                        self.DELETE_CVE_DATA[eco].append(data)
-                        self.DELTA_FEED[eco].append(data)
-                        self.SNYK_REPORT['details'][eco]['delete'][data['id']] = {
-                            'name': pkg,
-                            'status': "skipped"
-                        }
+                        self._add_data_for_false_positives(eco, data, pkg)
                         continue
                     """ This is done so that we dont fetch the same pkg data again & again if more
                     than 1 vuln for the same pkg is present."""
@@ -385,16 +311,13 @@ class SnykCveSync:
                             commit hash usecase, even when affected versions not found"""
                             logger.info("No affected versions for {}".format(data['id']))
                         total_vuln += 1
-                        del data['rules']
-                        data['description'] = re.sub("[\'\"]", "", data['description'])
-                        premium = str(data.get('premium', "false")).lower() == 'true'
-                        data['pvtVuln'] = premium
+                        data = self._set_additional_fields(data)
                         # In Snyk feed, for some golang vuln, they dont have this field.
                         if 'vulnerableHashes' not in data:
                             data['vulnerableHashes'] = []
                         self.SNYK_REPORT['details'][eco]['ingest'][data['id']] = {
                             'name': pkg,
-                            'premium': premium,
+                            'premium': data['pvtVuln'],
                             'affected_version_count': len(data['affected']),
                             'affected_commit_hash_count': len(data['vulnerableHashes']),
                             'status': "skipped"
@@ -417,9 +340,6 @@ class SnykCveSync:
         total_vuln = 0
         delta_mode = self.helper.is_delta_mode_on()
         if len(vuln_data) != 0:
-            self.CVE_DATA[eco] = {}
-            self.DELETE_CVE_DATA[eco] = []
-            self.DELTA_FEED[eco] = []
             for data in vuln_data:
                 if eco == "pypi":
                     data['package'] = str.lower(data['package'])
@@ -433,12 +353,7 @@ class SnykCveSync:
                     if len(data['vulnerableVersions']) == 0:
                         # In this case, we use the data to remove the vuln from the garph
                         logger.info("False positive found. {i}".format(i=data['id']))
-                        self.DELETE_CVE_DATA[eco].append(data)
-                        self.DELTA_FEED[eco].append(data)
-                        self.SNYK_REPORT['details'][eco]['delete'][data['id']] = {
-                            'name': pkg,
-                            'status': "skipped"
-                        }
+                        self._add_data_for_false_positives(eco, data, pkg)
                         continue
                     """ This is done so that we dont fetch the same pkg data again & again if more
                     than 1 vuln for the same pkg is present."""
@@ -471,16 +386,13 @@ class SnykCveSync:
                                         .format(pkg))
                             continue
                         total_vuln += 1
-                        del data['rules']
                         self.CVE_DATA[eco][pkg]['affected'].extend(data['affected'])
                         self.CVE_DATA[eco][pkg]['affected'] = list(
                             set(self.CVE_DATA[eco][pkg]['affected']))
-                        data['description'] = re.sub("[\'\"]", "", data['description'])
-                        premium = str(data.get('premium', "false")).lower() == 'true'
-                        data['pvtVuln'] = premium
+                        data = self._set_additional_fields(data)
                         # Update the premium value and the affected version count in report.
                         rep_obj = self.SNYK_REPORT['details'][eco]['ingest'][data['id']]
-                        rep_obj['premium'] = premium
+                        rep_obj['premium'] = data['pvtVuln']
                         rep_obj['affected_version_count'] = len(data['affected'])
                         self.DELTA_FEED[eco].append(data)
                         self.CVE_DATA[eco][pkg]['vulnerabilities'].append(data)

--- a/graph_snyk_cve_sync.py
+++ b/graph_snyk_cve_sync.py
@@ -33,6 +33,7 @@ import time
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+SUPPORTED_ECOSYSTEMS = ['maven', 'npm', 'pypi', 'golang']
 
 
 class Helper:
@@ -309,6 +310,11 @@ class SnykCveSync:
         }
         # 2 extra fields are needed in case of golang for github url and license details
         if eco == "golang":
+            checked_versions = []
+            # This is required to remove all commit hash released as versions in golang.
+            for ver in versions:
+                if "v0.0.0-" not in ver:
+                    checked_versions.append(ver)
             obj['gh_link'] = gh
             obj['license'] = lic
         return obj
@@ -352,7 +358,7 @@ class SnykCveSync:
                             # As we are relying on web scraping, we might get None in some cases.
                             latest_version = go_utils.get_latest_version() or ""
                             gh_link = go_utils.get_gh_link() or ""
-                            lic = go_utils.get_license() or ""
+                            lic = go_utils.get_license() or []
                             self.CVE_DATA[eco][pkg] = self._generate_default_cve_obj(
                                 eco, pkg, versions, latest_version, gh_link, lic)
 
@@ -362,6 +368,7 @@ class SnykCveSync:
                             self.SNYK_REPORT['details'][eco]['pvt_pkgs'][data['id']] = {
                                 'name': pkg
                             }
+                            continue
                     logger.info("Processing {}".format(data['id']))
                     versions = self.CVE_DATA[eco][pkg]['all_ver']
                     if versions:
@@ -498,7 +505,7 @@ class SnykCveSync:
         dry_run = self.helper.is_dry_run()
         if dry_run:
             logger.info("Dry run mode is on. No ingestion will take place".center(30, '-'))
-        for eco in ('maven', 'npm', 'pypi', 'golang'):
+        for eco in SUPPORTED_ECOSYSTEMS:
             if eco in self.CVE_DATA:
                 logger.info("Inserting {} CVEs...".format(eco))
                 for pkg in self.CVE_DATA[eco]:
@@ -525,7 +532,7 @@ class SnykCveSync:
         if dry_run:
             logger.info("Dry run mode is on. No ingestion will take place".center(30, '-'))
         del_obj = {'id': ''}
-        for eco in ('maven', 'npm', 'pypi', 'golang'):
+        for eco in SUPPORTED_ECOSYSTEMS:
             if eco in self.DELETE_CVE_DATA:
                 logger.info("Deleting false positive {} CVEs...".format(eco))
                 for vuln in self.DELETE_CVE_DATA[eco]:
@@ -555,7 +562,7 @@ class SnykCveSync:
         """Generate the ingestion report for snyk."""
         details = self.SNYK_REPORT['details']
         stats = self.SNYK_REPORT['stats']
-        for eco in ("maven", "pypi", "npm", 'golang'):
+        for eco in SUPPORTED_ECOSYSTEMS:
             eco_details = details[eco]
             eco_stats = stats[eco]
             # Calculate the number of vulnerabilities pointing to pvt pkgs.

--- a/graph_snyk_cve_sync.py
+++ b/graph_snyk_cve_sync.py
@@ -427,7 +427,7 @@ class SnykCveSync:
         for eco in SUPPORTED_ECOSYSTEMS:
             if eco in self.CVE_DATA:
                 logger.info("Inserting {} CVEs...".format(eco))
-                if len(self.CVE_DATA[eco]) >0:
+                if len(self.CVE_DATA[eco]) > 0:
                     for pkg in self.CVE_DATA[eco]:
                         cves = self.CVE_DATA[eco][pkg]
                         # If there are not cves for a pkg, we need to ignore it.

--- a/graph_snyk_cve_sync.py
+++ b/graph_snyk_cve_sync.py
@@ -59,8 +59,8 @@ class SnykCveSync:
                                                            "snyk-feed/")
             # For testing purpose we can use the sample feed
             """with open('data/feed_sample.json', encoding='utf-8') as f:
-                x = json.loads(f)
-            self.snyk_data = x"""
+                x = json.load(f)"""
+            self.snyk_data = x
         else:
             self.snyk_data = data
         self.SNYK_REPORT = self._populate_default_report()
@@ -280,7 +280,6 @@ class SnykCveSync:
                         then only we can go ahead fetch and create nodes, else we need to ignore
                         for the time being."""
                         if versions:
-                            data['ecosystem'] = eco
                             # As we are relying on web scraping, we might get None in some cases.
                             latest_version = go_utils.get_latest_version() or ""
                             gh_link = go_utils.get_gh_link() or ""
@@ -297,6 +296,7 @@ class SnykCveSync:
                             continue
                     logger.info("Processing {}".format(data['id']))
                     versions = self.CVE_DATA[eco][pkg]['all_ver']
+                    data['ecosystem'] = eco
                     if versions:
                         vuln_versions = data['vulnerableVersions']
                         data['rules'] = self._get_version_rules(vuln_versions)
@@ -310,16 +310,23 @@ class SnykCveSync:
                             """ This will make sure vuln node gets created which can be used for
                             commit hash usecase, even when affected versions not found"""
                             logger.info("No affected versions for {}".format(data['id']))
+                            continue
                         total_vuln += 1
                         data = self._set_additional_fields(data)
                         # In Snyk feed, for some golang vuln, they dont have this field.
-                        if 'vulnerableHashes' not in data:
-                            data['vulnerableHashes'] = []
+                        if 'vulnerableHashes' in data:
+                            del data['vulnerableHashes']
+                        """
+                        else:
+                            hashes = []
+                            for hash in data['vulnerableHashes']:
+                                hashes.append(hash[:7])
+                            data['vulnerableHashes'] = hashes """
+
                         self.SNYK_REPORT['details'][eco]['ingest'][data['id']] = {
                             'name': pkg,
                             'premium': data['pvtVuln'],
                             'affected_version_count': len(data['affected']),
-                            'affected_commit_hash_count': len(data['vulnerableHashes']),
                             'status': "skipped"
                         }
                         self.DELTA_FEED[eco].append(data)
@@ -420,19 +427,23 @@ class SnykCveSync:
         for eco in SUPPORTED_ECOSYSTEMS:
             if eco in self.CVE_DATA:
                 logger.info("Inserting {} CVEs...".format(eco))
-                for pkg in self.CVE_DATA[eco]:
-                    cves = self.CVE_DATA[eco][pkg]
-                    # If there are not cves for a pkg, we need to ignore it.
-                    if len(cves['vulnerabilities']) > 0:
-                        logger.info("Inserting CVEs for pkg: {}".format(pkg))
-                        logger.debug(cves)
-                        if not dry_run:
-                            resp = self.helper.make_api_call(cves, 'PUT')
-                            for cve in cves['vulnerabilities']:
-                                cve_id = cve['id']
-                                self.SNYK_REPORT['details'][eco]['ingest'][cve_id]['status'] = resp
-                        logger.info("Waiting for 1 second".center(30, '-'))
-                        time.sleep(1)
+                if len(self.CVE_DATA[eco]) >0:
+                    for pkg in self.CVE_DATA[eco]:
+                        cves = self.CVE_DATA[eco][pkg]
+                        # If there are not cves for a pkg, we need to ignore it.
+                        if len(cves['vulnerabilities']) > 0:
+                            logger.info("Inserting CVEs for pkg: {}".format(pkg))
+                            logger.debug(cves)
+                            if not dry_run:
+                                resp = self.helper.make_api_call(cves, 'PUT')
+                                for cve in cves['vulnerabilities']:
+                                    cve_id = cve['id']
+                                    rep_details = self.SNYK_REPORT['details']
+                                    rep_details[eco]['ingest'][cve_id]['status'] = resp
+                            logger.info("Waiting for 1 second".center(30, '-'))
+                            time.sleep(1)
+                else:
+                    logger.info("Nothing to insert for {} CVEs...".format(eco))
             else:
                 logger.info("Nothing to insert for {} CVEs...".format(eco))
         return True
@@ -447,14 +458,17 @@ class SnykCveSync:
         for eco in SUPPORTED_ECOSYSTEMS:
             if eco in self.DELETE_CVE_DATA:
                 logger.info("Deleting false positive {} CVEs...".format(eco))
-                for vuln in self.DELETE_CVE_DATA[eco]:
-                    logger.info("Deleting {}".format(vuln['id']))
-                    del_obj['id'] = vuln['id']
-                    if not dry_run:
-                        resp = self.helper.make_api_call(del_obj, 'DELETE')
-                        self.SNYK_REPORT['details'][eco]['delete'][vuln['id']]['status'] = resp
-                    logger.info("Waiting for 1 second".center(30, '-'))
-                    time.sleep(1)
+                if len(self.DELETE_CVE_DATA[eco]) > 0:
+                    for vuln in self.DELETE_CVE_DATA[eco]:
+                        logger.info("Deleting {}".format(vuln['id']))
+                        del_obj['id'] = vuln['id']
+                        if not dry_run:
+                            resp = self.helper.make_api_call(del_obj, 'DELETE')
+                            self.SNYK_REPORT['details'][eco]['delete'][vuln['id']]['status'] = resp
+                        logger.info("Waiting for 1 second".center(30, '-'))
+                        time.sleep(1)
+                else:
+                    logger.info("Nothing to delete for {} CVEs...".format(eco))
             else:
                 logger.info("Nothing to delete for {} CVEs...".format(eco))
         logger.info("Deletion of data ends".center(50, '-'))
@@ -511,8 +525,10 @@ class SnykCveSync:
                     total_ing += 1
                     pkgs.append(eco_details['ingest'][ing_vuln]['name'])
                     ver_count += eco_details['ingest'][ing_vuln]['affected_version_count']
+                    """
                     if eco == "golang":
                         hash_count += eco_details['ingest'][ing_vuln]['affected_commit_hash_count']
+                        """
                     if eco_details['ingest'][ing_vuln]['status'] == "success":
                         success_ing += 1
                     if eco_details['ingest'][ing_vuln]['premium']:

--- a/graph_snyk_cve_sync.py
+++ b/graph_snyk_cve_sync.py
@@ -22,6 +22,7 @@ import boto3
 import json
 import os
 from f8a_utils.versions import get_versions_and_latest_for_ep
+from f8a_utils.golang_utils import GolangUtils
 from unified_range import api
 from f8a_version_comparator.comparable_version import ComparableVersion
 import re
@@ -110,18 +111,22 @@ class Helper:
 
     def is_dry_run(self):
         """Return True if this is a dry run."""
+        # Set this value to true if you want the entire operation to run, but not the ingestion.
         return os.environ.get('SNYK_DRY_RUN', 'false').lower() in ('1', 'yes', 'true')
 
     def force_run_ingestion(self):
         """Return if ingestion mode is on."""
+        # Set this value when you want to run the ingestion forcefully (ignores runtime).
         return os.environ.get('SNYK_INGESTION_FORCE_RUN', 'false').lower() in ('1', 'yes', 'true')
 
     def is_delta_mode_on(self):
         """Return if the delta feed mode is on."""
+        # Set this value if you want to run only in the diff mode.
         return os.environ.get('SNYK_DELTA_FEED_MODE', 'false').lower() in ('1', 'yes', 'true')
 
     def ingestion_run_time(self):
         """Return the time when ingestion needs to run."""
+        # Set the time at which you want the ingestion to run.
         return os.environ.get('SNYK_INGESTION_RUN_TIME', '12')
 
 
@@ -137,75 +142,31 @@ class SnykCveSync:
         self.utc_now = datetime.utcnow()
         self.today = self.utc_now.replace(hour=0, minute=0, second=0, microsecond=0)
         self.day = self.utc_now.weekday()
+
+        # This is the offset days i.e how many days old data do we need to ingest.
         delta_feed_offset = int(os.environ.get('SNYK_DELTA_FEED_OFFSET', '1'))
         self.start_day = self.today - timedelta(days=delta_feed_offset)
         self.selective_eco_run = os.environ.get('SELECTIVE_ECOSYSTEM_SNYK_SYNC', 'none')
+
+        # If we want to selectively run the ingestion for an ecosystem.
+        self.selective_eco_run = os.environ.get('SELECTIVE_ECOSYSTEM_SNYK_SYNC', '')
         if not data:
             self.snyk_data = self.helper.read_data_from_s3(self.utc_now.strftime('%d-%m-%Y'),
                                                            "snyk-feed/")
+            # For testing purpose we can use the sample feed
+            """with open('data/feed_sample.json', encoding='utf-8') as f:
+                x = json.loads(f)
+            self.snyk_data = x"""
         else:
             self.snyk_data = data
         self.SNYK_REPORT = self._populate_default_report()
 
     def _populate_default_report(self):
         """Generate a default report."""
-        return {
-            "stats": {
-                "maven": {
-                    "successfully_ingested": 0,
-                    "to_be_ingested": 0,
-                    "ingestion_accuracy": "",
-                    "successfully_deleted": 0,
-                    "to_be_deleted": 0,
-                    "deletion_accuracy": "",
-                    "packages_affected": 0,
-                    "versions_affected": 0,
-                    "premium_count": 0,
-                    "pvt_pkg_vulnerability_count": 0
-                },
-                "pypi": {
-                    "successfully_ingested": 0,
-                    "to_be_ingested": 0,
-                    "ingestion_accuracy": "",
-                    "successfully_deleted": 0,
-                    "to_be_deleted": 0,
-                    "deletion_accuracy": "",
-                    "packages_affected": 0,
-                    "versions_affected": 0,
-                    "premium_count": 0,
-                    "pvt_pkg_vulnerability_count": 0
-                },
-                "npm": {
-                    "successfully_ingested": 0,
-                    "to_be_ingested": 0,
-                    "ingestion_accuracy": "",
-                    "successfully_deleted": 0,
-                    "to_be_deleted": 0,
-                    "deletion_accuracy": "",
-                    "packages_affected": 0,
-                    "versions_affected": 0,
-                    "premium_count": 0,
-                    "pvt_pkg_vulnerability_count": 0
-                }
-            },
-            "details": {
-                "maven": {
-                    "ingest": {},
-                    "delete": {},
-                    "pvt_pkgs": {}
-                },
-                "pypi": {
-                    "ingest": {},
-                    "delete": {},
-                    "pvt_pkgs": {}
-                },
-                "npm": {
-                    "ingest": {},
-                    "delete": {},
-                    "pvt_pkgs": {}
-                }
-            }
-        }
+        # Read the default value of the report from a file.
+        with open('data/default_report.json', encoding='utf-8') as f:
+            data = json.load(f)
+        return data
 
     def _parse_data_for_eco(self, eco):
         """Return True/False depending on whether the ecosysytem data should be parsed or not."""
@@ -216,17 +177,22 @@ class SnykCveSync:
         elif self.selective_eco_run != "none":
             return False
         day = str(self.day)
-        if (day in ["0", "3"] and eco == "java") \
-                or (day in ["1", "4"] and eco == "js") \
-                or (day in ["2", "5"] and eco == "python"):
+        # The weekdays here will be in use only when running it in bootstrap mode.
+        if (day in ["0", "4"] and eco == "java") \
+                or (day in ["1", "5"] and eco == "js") \
+                or (day in ["2", "6"] and eco == "python") \
+                or (day in ["3"] and eco == "golang"):
             return True
         return False
 
     def _get_version_rules(self, vuln_versions):
-        """Version rules for pypi,maven eco."""
+        """Version rules for all eco."""
         rules = []
         regex_op = "[0-9a-zA-Z\\_\\.\\-]+"
         regex_vr = "[<>=*]+"
+        """For all the vulnerable versions information that we get, we need to create
+        comparable version object so that we can apply these rules on top of all the available
+        versions of a pkg in the market."""
         for version in vuln_versions:
             version = version.replace(" ", "")
             sub_vers = version.split('||')
@@ -234,11 +200,13 @@ class SnykCveSync:
                 tmp = []
                 vr_relations = re.split(regex_vr, sub_ver)
                 op_relations = re.split(regex_op, sub_ver)
+                # Single affected version.
                 if len(vr_relations) == 1:
                     tmp.append({
                         'key': "=",
                         'val': ComparableVersion(vr_relations[0])
                     })
+                # All versions affected.
                 elif len(op_relations) == 1 and op_relations[0] == '*':
                     tmp.append({
                         'key': "*",
@@ -268,15 +236,18 @@ class SnykCveSync:
             return ComparableVersion(version) >= rule
         elif key == '*':
             return True
+        return False
 
     def _get_affected_versions(self, rules, versions):
         """Get affected versions for maven, pypi, npm."""
         affected = []
         for ver in versions:
             for rule in rules:
+                # If there is a singular rule Ex >=2.1.1
                 if len(rule) == 1:
                     if self._is_relation_applicable(rule[0]['key'], ver, rule[0]['val']):
                         affected.append(ver)
+                # If there are 2 rules Ex >=2.1.1 & <2.1.5
                 elif len(rule) == 2:
                     key0 = rule[0]['key']
                     key1 = rule[1]['key']
@@ -312,13 +283,127 @@ class SnykCveSync:
             elif eco == "python" and self._parse_data_for_eco(eco):
                 logger.info("Parsing feed for Pypi.")
                 self._parse_data(self.snyk_data[eco], "pypi")
+            elif eco == "golang" and self._parse_data_for_eco(eco):
+                logger.info("Parsing feed for Golang.")
+                self._parse_golang_data(self.snyk_data[eco], "golang")
             else:
                 logger.info("Ignoring the ecosystem {} from the feed".format(eco))
 
     def _is_date_in_range(self, date):
         """Check to see if the date of vuln falls in the range."""
         date_obj = datetime.strptime(date.split('T')[0], '%Y-%m-%d')
+        """When running under delta feed mode, we need to consider only those vulns which were
+        updated between the given offset date and today's date."""
         return self.today > date_obj >= self.start_day
+
+    def _generate_default_cve_obj(self, eco, pkg, versions, latest, gh=None, lic=None):
+        """Generate the default cve object."""
+        # Generate the default snyk cve object.
+        obj = {
+            "affected": [],
+            "vulnerabilities": [],
+            "all_ver": versions,
+            "latest_version": latest,
+            "ecosystem": eco,
+            "package": pkg
+        }
+        # 2 extra fields are needed in case of golang for github url and license details
+        if eco == "golang":
+            obj['gh_link'] = gh
+            obj['license'] = lic
+        return obj
+
+    def _parse_golang_data(self, vuln_data, eco):
+        """Parse data for golang eco."""
+        total_vuln = 0
+        delta_mode = self.helper.is_delta_mode_on()
+        if len(vuln_data) != 0:
+            self.CVE_DATA[eco] = {}
+            self.DELETE_CVE_DATA[eco] = []
+            self.DELTA_FEED[eco] = []
+            for data in vuln_data:
+                # If delta mode is on & the modificationTime doesnt fall in the range, then ignore.
+                if delta_mode and not self._is_date_in_range(data['modificationTime']):
+                    logger.debug("No new updates for {}".format(data['id']))
+                    continue
+                pkg = data['package']
+                logger.debug("Fetching details for package: {}".format(pkg))
+                try:
+                    if len(data['vulnerableVersions']) == 0:
+                        # In this case, we use the data to remove the vuln from the garph
+                        logger.info("False positive found. {i}".format(i=data['id']))
+                        self.DELETE_CVE_DATA[eco].append(data)
+                        self.DELTA_FEED[eco].append(data)
+                        self.SNYK_REPORT['details'][eco]['delete'][data['id']] = {
+                            'name': pkg,
+                            'status': "skipped"
+                        }
+                        continue
+                    """ This is done so that we dont fetch the same pkg data again & again if more
+                    than 1 vuln for the same pkg is present."""
+                    if pkg not in self.CVE_DATA[eco]:
+                        go_utils = GolangUtils(pkg)
+                        versions = go_utils.get_all_versions()
+                        """ From the available options we have in scraping, if we get the details
+                        then only we can go ahead fetch and create nodes, else we need to ignore
+                        for the time being."""
+                        if versions:
+                            data['ecosystem'] = eco
+                            # As we are relying on web scraping, we might get None in some cases.
+                            latest_version = go_utils.get_latest_version() or ""
+                            gh_link = go_utils.get_gh_link() or ""
+                            lic = go_utils.get_license() or ""
+                            self.CVE_DATA[eco][pkg] = self._generate_default_cve_obj(
+                                eco, pkg, versions, latest_version, gh_link, lic)
+
+                        else:
+                            # TODO we need to decide what we need to do when we dont find any data.
+                            logger.info("No details about the pkg {} found.".format(pkg))
+                            self.SNYK_REPORT['details'][eco]['pvt_pkgs'][data['id']] = {
+                                'name': pkg
+                            }
+                    logger.info("Processing {}".format(data['id']))
+                    versions = self.CVE_DATA[eco][pkg]['all_ver']
+                    if versions:
+                        vuln_versions = data['vulnerableVersions']
+                        data['rules'] = self._get_version_rules(vuln_versions)
+                        data['affected'] = self._get_affected_versions(data['rules'], versions)
+                        # Create edges for vuln only when affected versions found.
+                        if len(data['affected']) != 0:
+                            self.CVE_DATA[eco][pkg]['affected'].extend(data['affected'])
+                            self.CVE_DATA[eco][pkg]['affected'] = list(
+                                set(self.CVE_DATA[eco][pkg]['affected']))
+                        else:
+                            """ This will make sure vuln node gets created which can be used for
+                            commit hash usecase, even when affected versions not found"""
+                            logger.info("No affected versions for {}".format(data['id']))
+                        total_vuln += 1
+                        del data['rules']
+                        data['description'] = re.sub("[\'\"]", "", data['description'])
+                        premium = str(data.get('premium', "false")).lower() == 'true'
+                        data['pvtVuln'] = premium
+                        # In Snyk feed, for some golang vuln, they dont have this field.
+                        if 'vulnerableHashes' not in data:
+                            data['vulnerableHashes'] = []
+                        self.SNYK_REPORT['details'][eco]['ingest'][data['id']] = {
+                            'name': pkg,
+                            'premium': premium,
+                            'affected_version_count': len(data['affected']),
+                            'affected_commit_hash_count': len(data['vulnerableHashes']),
+                            'status': "skipped"
+                        }
+                        self.DELTA_FEED[eco].append(data)
+                        self.CVE_DATA[eco][pkg]['vulnerabilities'].append(data)
+                except ValueError:
+                    logger.error("Encountered a Value Error while trying to fetch versions for "
+                                 "{e} -> {p}".format(e=eco, p=pkg))
+                except AttributeError:
+                    logger.error("Encountered an Attribute Error while trying to fetch details for "
+                                 "{e} -> {p}".format(e=eco, p=pkg))
+        logger.info("{} Data".format(eco).center(50, '-'))
+        logger.info("Total affected packages: {}".format(len(self.CVE_DATA[eco])))
+        logger.info("Total vulnerabilities: {}".format(total_vuln))
+        logger.debug(self.CVE_DATA[eco])
 
     def _parse_data(self, vuln_data, eco):
         """Parse data for all eco."""
@@ -339,6 +424,7 @@ class SnykCveSync:
                 try:
                     versions = None
                     if len(data['vulnerableVersions']) == 0:
+                        # In this case, we use the data to remove the vuln from the garph
                         logger.info("False positive found. {i}".format(i=data['id']))
                         self.DELETE_CVE_DATA[eco].append(data)
                         self.DELTA_FEED[eco].append(data)
@@ -347,23 +433,25 @@ class SnykCveSync:
                             'status': "skipped"
                         }
                         continue
+                    """ This is done so that we dont fetch the same pkg data again & again if more
+                    than 1 vuln for the same pkg is present."""
                     if pkg not in self.CVE_DATA[eco]:
                         resp_obj = get_versions_and_latest_for_ep(eco, pkg)
                         if resp_obj and (not isinstance(resp_obj, list)) \
                                 and 'versions' in resp_obj and len(resp_obj['versions']) > 0:
                             versions = resp_obj['versions']
-                            self.CVE_DATA[eco][pkg] = {
-                                "affected": [],
-                                "vulnerabilities": [],
-                                "all_ver": versions,
-                                "latest_version": resp_obj['latest_version'],
-                                "ecosystem": eco,
-                                "package": pkg
-                            }
+                            self.CVE_DATA[eco][pkg] = self._generate_default_cve_obj(
+                                eco, pkg, versions, resp_obj['latest_version'])
                     else:
                         versions = self.CVE_DATA[eco][pkg]['all_ver']
                     if versions:
                         logger.info("Processing {}".format(data['id']))
+                        self.SNYK_REPORT['details'][eco]['ingest'][data['id']] = {
+                            'name': pkg,
+                            'premium': False,
+                            'affected_version_count': 0,
+                            'status': "skipped"
+                        }
                         data['ecosystem'] = eco
                         if eco in ['maven', 'pypi']:
                             vuln_versions = self._get_semver_versions(data['vulnerableVersions'])
@@ -372,12 +460,6 @@ class SnykCveSync:
                         data['rules'] = self._get_version_rules(vuln_versions)
                         data['affected'] = self._get_affected_versions(data['rules'], versions)
                         if len(data['affected']) == 0:
-                            self.SNYK_REPORT['details'][eco]['ingest'][data['id']] = {
-                                'name': pkg,
-                                'premium': False,
-                                'affected_version_count': 0,
-                                'status': "skipped"
-                            }
                             logger.info("No active affected version found for {}. Ignored."
                                         .format(pkg))
                             continue
@@ -387,14 +469,12 @@ class SnykCveSync:
                         self.CVE_DATA[eco][pkg]['affected'] = list(
                             set(self.CVE_DATA[eco][pkg]['affected']))
                         data['description'] = re.sub("[\'\"]", "", data['description'])
-                        premium = str(data['premium']).lower() == 'true'
+                        premium = str(data.get('premium', "false")).lower() == 'true'
                         data['pvtVuln'] = premium
-                        self.SNYK_REPORT['details'][eco]['ingest'][data['id']] = {
-                            'name': pkg,
-                            'premium': premium,
-                            'affected_version_count': len(data['affected']),
-                            'status': "skipped"
-                        }
+                        # Update the premium value and the affected version count in report.
+                        rep_obj = self.SNYK_REPORT['details'][eco]['ingest'][data['id']]
+                        rep_obj['premium'] = premium
+                        rep_obj['affected_version_count'] = len(data['affected'])
                         self.DELTA_FEED[eco].append(data)
                         self.CVE_DATA[eco][pkg]['vulnerabilities'].append(data)
 
@@ -418,11 +498,12 @@ class SnykCveSync:
         dry_run = self.helper.is_dry_run()
         if dry_run:
             logger.info("Dry run mode is on. No ingestion will take place".center(30, '-'))
-        for eco in ('maven', 'npm', 'pypi'):
+        for eco in ('maven', 'npm', 'pypi', 'golang'):
             if eco in self.CVE_DATA:
                 logger.info("Inserting {} CVEs...".format(eco))
                 for pkg in self.CVE_DATA[eco]:
                     cves = self.CVE_DATA[eco][pkg]
+                    # If there are not cves for a pkg, we need to ignore it.
                     if len(cves['vulnerabilities']) > 0:
                         logger.info("Inserting CVEs for pkg: {}".format(pkg))
                         logger.debug(cves)
@@ -444,7 +525,7 @@ class SnykCveSync:
         if dry_run:
             logger.info("Dry run mode is on. No ingestion will take place".center(30, '-'))
         del_obj = {'id': ''}
-        for eco in ('maven', 'npm', 'pypi'):
+        for eco in ('maven', 'npm', 'pypi', 'golang'):
             if eco in self.DELETE_CVE_DATA:
                 logger.info("Deleting false positive {} CVEs...".format(eco))
                 for vuln in self.DELETE_CVE_DATA[eco]:
@@ -474,7 +555,7 @@ class SnykCveSync:
         """Generate the ingestion report for snyk."""
         details = self.SNYK_REPORT['details']
         stats = self.SNYK_REPORT['stats']
-        for eco in ("maven", "pypi", "npm"):
+        for eco in ("maven", "pypi", "npm", 'golang'):
             eco_details = details[eco]
             eco_stats = stats[eco]
             # Calculate the number of vulnerabilities pointing to pvt pkgs.
@@ -489,14 +570,15 @@ class SnykCveSync:
                     total_del += 1
                     if eco_details['delete'][del_vuln]['status'] == "success":
                         success_del += 1
+                # Deletion accuracy calculation.
                 eco_stats['successfully_deleted'] = success_del
                 eco_stats['to_be_deleted'] = total_del
                 eco_stats['deletion_accuracy'] = str(round((
                         (success_del * 100) / total_del), 2)) + "%"
 
             else:
+                # When there is no data available for an eco, this default data is populated.
                 eco_stats['successfully_deleted'] = 0
-                eco_stats['to_be_deleted'] = 0
                 eco_stats['deletion_accuracy'] = "NA"
 
             # Calculate the stats for vulnerabilities ingested.
@@ -505,21 +587,30 @@ class SnykCveSync:
                 total_ing = 0
                 pkgs = []
                 ver_count = 0
+                hash_count = 0
                 for ing_vuln in eco_details['ingest']:
                     total_ing += 1
                     pkgs.append(eco_details['ingest'][ing_vuln]['name'])
                     ver_count += eco_details['ingest'][ing_vuln]['affected_version_count']
+                    if eco == "golang":
+                        hash_count += eco_details['ingest'][ing_vuln]['affected_commit_hash_count']
                     if eco_details['ingest'][ing_vuln]['status'] == "success":
                         success_ing += 1
                     if eco_details['ingest'][ing_vuln]['premium']:
                         eco_stats['premium_count'] += 1
+                # Ingestion accuracy calculation.
                 eco_stats['successfully_ingested'] = success_ing
                 eco_stats['to_be_ingested'] = total_ing
                 eco_stats['ingestion_accuracy'] = str(round((
                         (success_ing * 100) / total_ing), 2)) + "%"
+                # Total affected pkgs and versions count.
                 eco_stats['packages_affected'] = len(list(set(pkgs)))
                 eco_stats['versions_affected'] = ver_count
+                # The details of commit hash count is needed only in case of golang.
+                if eco == "golang":
+                    eco_stats['commit_hash_affected'] = hash_count
             else:
+                # When there is no data available for an eco, this default data is populated.
                 eco_stats['successfully_ingested'] = 0
                 eco_stats['ingestion_accuracy'] = "NA"
 

--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright © 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Author: Yusuf Zainee <yzainee@redhat.com>
+#
+
+"""Helper functions for the graph sync operations."""
+
+import requests
+import logging
+import os
+import boto3
+import json
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class Helper:
+    """Helper class with some utility functions."""
+
+    def __init__(self):
+        """Init method for helper class."""
+        self.CVE_BUCKET = os.environ.get("REPORT_BUCKET_NAME", '')
+        self.AWS_KEY = os.environ.get("AWS_S3_ACCESS_KEY_ID_REPORT_BUCKET", '')
+        self.AWS_SECRET = os.environ.get("AWS_S3_SECRET_ACCESS_KEY_REPORT_BUCKET", '')
+        self.AWS_REGION = os.environ.get("AWS_S3_REGION", "us-east-1")
+        self.HOST = os.environ.get('BAYESIAN_DATA_IMPORTER_SERVICE_HOST', 'bayesian-data-importer')
+        self.PORT = os.environ.get('BAYESIAN_DATA_IMPORTER_SERVICE_PORT', '9192')
+
+        self.s3_resource = boto3.resource('s3', aws_access_key_id=self.AWS_KEY,
+                                          aws_secret_access_key=self.AWS_SECRET,
+                                          region_name=self.AWS_REGION)
+
+    def store_json_content(self, content, obj_key):
+        """Store the report content to the S3 storage."""
+        try:
+            logger.info('Storing the data into the S3 file %s' % obj_key)
+            self.s3_resource.Object(self.CVE_BUCKET, obj_key).put(
+                Body=json.dumps(content, indent=2).encode('utf-8'))
+        except Exception as e:
+            logger.exception('%r' % e)
+
+    def _retrieve_dict(self, object_key):
+        """Retrieve a dictionary stored as JSON from S3."""
+        return json.loads(self._retrieve_blob(object_key).decode('utf-8'))
+
+    def _retrieve_blob(self, object_key):
+        """Retrieve remote object content."""
+        return self.s3_resource.Object(self.CVE_BUCKET, object_key).get()['Body'].read()
+
+    def read_data_from_s3(self, date, loc):
+        """Read the snyk data from S3."""
+        try:
+            filename = loc + date + ".json"
+            logger.info('Retrieving the data from the S3 file %s' % filename)
+            return self._retrieve_dict(filename)
+        except Exception as e:
+            logger.error(e)
+            return False
+
+    def make_api_call(self, payload, mode):
+        """Make an API call to data importer."""
+        try:
+            api_url = "http://" + self.HOST + ":" + self.PORT
+            headers = {'Content-type': 'application/json'}
+            msg = ""
+            response = ""
+            if mode == "PUT":
+                response = requests.put('{}/api/v1/snyk-cves'.format(api_url), headers=headers,
+                                        data=json.dumps(payload))
+                msg = "ingested"
+                key = payload['package']
+            elif mode == "DELETE":
+                response = requests.delete('{}/api/v1/snyk-cves'.format(api_url), headers=headers,
+                                           data=json.dumps(payload))
+                msg = "deleted"
+                key = payload['id']
+            if response.status_code == 200:
+                logger.info("CVEs for {p} successfully {m}".format(p=key, m=msg))
+                return "success"
+            elif response.status_code == 504:
+                logger.info("Operation for {p} is taking time. "
+                            "Will be {m} in the background".format(p=key, m=msg))
+                return "delayed"
+            else:
+                logger.info("Error while {m} CVEs for {p}".format(p=key, m=msg))
+                logger.info("Status Code {}".format(response.status_code))
+            return "failed"
+        except Exception:
+            logger.error("API call to data importer failed.")
+
+    def is_dry_run(self):
+        """Return True if this is a dry run."""
+        # Set this value to true if you want the entire operation to run, but not the ingestion.
+        return os.environ.get('SNYK_DRY_RUN', 'false').lower() in ('1', 'yes', 'true')
+
+    def force_run_ingestion(self):
+        """Return if ingestion mode is on."""
+        # Set this value when you want to run the ingestion forcefully (ignores runtime).
+        return os.environ.get('SNYK_INGESTION_FORCE_RUN', 'false').lower() in ('1', 'yes', 'true')
+
+    def is_delta_mode_on(self):
+        """Return if the delta feed mode is on."""
+        # Set this value if you want to run only in the diff mode.
+        return os.environ.get('SNYK_DELTA_FEED_MODE', 'false').lower() in ('1', 'yes', 'true')
+
+    def ingestion_run_time(self):
+        """Return the time when ingestion needs to run."""
+        # Set the time at which you want the ingestion to run.
+        return os.environ.get('SNYK_INGESTION_RUN_TIME', '12')

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ unified-range==0.0.9
 urllib3==1.24.3           # via botocore, requests
 git+https://git@github.com/fabric8-analytics/victimsdb-lib.git@3e2e72b#egg=victimsdb-lib
 git+https://git@github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@c3f3b3e#egg=f8a_version_comparator
-git+https://git@github.com/fabric8-analytics/fabric8-analytics-utils.git@54368f6#egg=fabric8-analytics-utils
+git+https://git@github.com/fabric8-analytics/fabric8-analytics-utils.git@1ad5559#egg=fabric8-analytics-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ unified-range==0.0.9
 urllib3==1.24.3           # via botocore, requests
 git+https://git@github.com/fabric8-analytics/victimsdb-lib.git@3e2e72b#egg=victimsdb-lib
 git+https://git@github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@c3f3b3e#egg=f8a_version_comparator
-git+https://git@github.com/fabric8-analytics/fabric8-analytics-utils.git@1f45e6f#egg=fabric8-analytics-utils
+git+https://git@github.com/fabric8-analytics/fabric8-analytics-utils.git@54368f6#egg=fabric8-analytics-utils

--- a/snyk_feed.py
+++ b/snyk_feed.py
@@ -98,7 +98,7 @@ class SnykDataFetcher:
         """Enable or disable snyk run.
         :return True if this needs to be run forcefully or if its saturday midnight.
         False otherwise."""
-        logger.info("Disable Snyk Syn {}".format(self.DISABLE_SNYK_SYNC_OPERATION))
+        logger.info("Disable Snyk Sync {}".format(self.DISABLE_SNYK_SYNC_OPERATION))
         logger.info("Force Snyk Run {}".format(self.helper.force_run_ingestion()))
         logger.info("Current Hour {}".format(date.strftime('%H')))
         logger.info("Ingestion Run Time {}".format(self.helper.ingestion_run_time()))

--- a/snyk_feed.py
+++ b/snyk_feed.py
@@ -24,7 +24,8 @@ import requests
 import logging
 import json
 from datetime import datetime
-from graph_snyk_cve_sync import Helper, SnykCveSync
+from graph_snyk_cve_sync import SnykCveSync
+from helper import Helper
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/tests/test_graph_snyk_cve_sync.py
+++ b/tests/test_graph_snyk_cve_sync.py
@@ -310,6 +310,60 @@ data = {
             "url": "https://snyk.io/vuln/SNYK-JS-DECOMPRESSTAR-559095",
             "vulnerableVersions": []
         }
+    ],
+    "golang": [
+        {
+            "description": "## Overview\n[go-g",
+            "exploit": "Not Defined",
+            "fixable": True,
+            "id": "SNYK-GOLANG-GITHUBCOMGOGITEAGITEA-72635",
+            "language": "golang",
+            "malicious": False,
+            "modificationTime": "2020-07-04T16:15:53.980730Z",
+            "package": "github.com/go-gitea/gitea",
+            "patchExists": False,
+            "references": [
+                {
+                    "title": "GitHub Issue",
+                    "url": "https://github.com/go-gitea/gitea/issues/5140"
+                }
+            ],
+            "severity": "high",
+            "title": "Remote Code Execution",
+            "url": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMGOGITEAGITEA-72635",
+            "vulnerableHashes": [
+                "cc3cbf8cbee4b28902abc7fccee60499bd4c1246",
+                "685631627e5c4db881160bfc9b39dc45143989f6"
+            ],
+            "vulnerableVersions": [
+                "<1.5.2"
+            ]
+        },
+        {
+            "description": "## Overview\n[go-g",
+            "exploit": "Not Defined",
+            "fixable": True,
+            "id": "SNYK-GOLANG-GITHUBCOMGOGITEAGITEA-72636",
+            "language": "golang",
+            "malicious": False,
+            "modificationTime": "2018-11-28T16:15:53.980730Z",
+            "package": "github.com/go-gitea/gitea",
+            "patchExists": False,
+            "references": [
+                {
+                    "title": "GitHub Issue",
+                    "url": "https://github.com/go-gitea/gitea/issues/5140"
+                }
+            ],
+            "severity": "high",
+            "title": "Remote Code Execution",
+            "url": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMGOGITEAGITEA-72635",
+            "vulnerableHashes": [
+                "cc3cbf8cbee4b28902abc7fccee60499bd4c1246",
+                "685631627e5c4db881160bfc9b39dc45143989f6"
+            ],
+            "vulnerableVersions": []
+        }
     ]
 }
 
@@ -327,29 +381,39 @@ def test_extract_data_from_feed(m1, m2):
     results = scs.CVE_DATA
     del_results = scs.DELETE_CVE_DATA
 
+    """Tests to check the valid run of create and delete scenarios for all 4 ecosystems."""
+
     assert "pypi" in del_results
     assert "npm" in del_results
     assert "maven" in del_results
+    assert "golang" in del_results
 
     assert len(del_results['pypi']) == 1
     assert len(del_results['maven']) == 1
     assert len(del_results['npm']) == 1
+    assert len(del_results['golang']) == 1
 
     assert "pypi" in results
     assert "npm" in results
     assert "maven" in results
+    assert "golang" in results
 
     assert "ansible" in results['pypi']
     assert "decompress-tar" in results['npm']
     assert "com.fasterxml.jackson.core:jackson-databind" in results['maven']
+    assert "github.com/go-gitea/gitea" in results['golang']
 
     py_pkg_obj = results['pypi']['ansible']
     npm_pkg_obj = results['npm']['decompress-tar']
     mv_pkg_obj = results['maven']['com.fasterxml.jackson.core:jackson-databind']
+    go_pkg_obj = results['golang']['github.com/go-gitea/gitea']
 
     assert py_pkg_obj['ecosystem'] == "pypi"
     assert npm_pkg_obj['ecosystem'] == "npm"
     assert mv_pkg_obj['ecosystem'] == "maven"
+    assert go_pkg_obj['ecosystem'] == "golang"
+    assert go_pkg_obj['gh_link']
+    assert go_pkg_obj['license']
 
     assert py_pkg_obj['affected']
     assert npm_pkg_obj['affected']
@@ -390,10 +454,11 @@ def test_extract_data_from_feed1(m1):
     results = scs.CVE_DATA
     del_results = scs.DELETE_CVE_DATA
     delta_feed = scs.DELTA_FEED
-    assert len(results) == 3
+    assert len(results) == 4
     assert len(results['maven']) == 1
     assert len(results['pypi']) == 1
     assert len(results['npm']) == 1
+    assert len(results['golang']) == 1
 
     assert "pypi" in del_results
     assert "npm" in del_results
@@ -456,6 +521,7 @@ def test_insert_cves(mocker):
         }
     }
     val = scs._insert_cves()
+    # Test insert CVEs in dry run mode.
     assert val is True
 
 
@@ -543,6 +609,7 @@ def test_delete_cves(mocker):
         ]
     }
     val = scs._delete_cves()
+    # Test delete CVEs in dry run mode.
     assert val is True
 
 
@@ -637,53 +704,65 @@ def test_is_delta_mode_on1():
 @patch('graph_snyk_cve_sync.Helper.is_delta_mode_on')
 def test_parse_data_for_eco(m1):
     """Test parse_data_for_eco."""
+    # Delta mode is on, so run for all ecosystems
     m1.return_value = True
     val = scs._parse_data_for_eco("js")
     assert val is True
 
+    # Delta mode is off, but selective eco is java, so run for java ecosystems
     m1.return_value = False
     scs.selective_eco_run = "java"
     val = scs._parse_data_for_eco("java")
     assert val is True
 
-    scs.day = datetime(2020, 5, 8, 12, 1).weekday()
-    val = scs._parse_data_for_eco("js")
-    assert val is False
-
-    m1.return_value = False
-    scs.selective_eco_run = "none"
-    scs.day = datetime(2020, 5, 8, 12, 1).weekday()
-    val = scs._parse_data_for_eco("js")
-    assert val is True
-
-    m1.return_value = False
+    # Delta mode is off, but selective eco is java, so dont run for npm ecosystems
     scs.day = datetime(2020, 5, 9, 12, 1).weekday()
     val = scs._parse_data_for_eco("js")
     assert val is False
 
-    val = scs._parse_data_for_eco("go")
+    # Delta mode is off, run for npm on saturday
+    m1.return_value = False
+    scs.selective_eco_run = "none"
+    scs.day = datetime(2020, 5, 9, 12, 1).weekday()
+    val = scs._parse_data_for_eco("js")
+    assert val is True
+
+    # Delta mode is off, dont run for npm on friday
+    m1.return_value = False
+    scs.day = datetime(2020, 5, 8, 12, 1).weekday()
+    val = scs._parse_data_for_eco("js")
+    assert val is False
+
+    # Dont run for non supported ecosystem
+    val = scs._parse_data_for_eco("ruby")
     assert val is False
 
 
 def test_is_relation_applicable():
     """Test is_relation_applicable."""
+    # Test lt operator
     res = scs._is_relation_applicable('<', '1.2', ComparableVersion('1.4'))
     assert res is True
     res = scs._is_relation_applicable('<', '1.4', ComparableVersion('1.4'))
     assert res is False
 
+    # Test gt operator
     res = scs._is_relation_applicable('>', '1.4', ComparableVersion('1.4'))
     assert res is False
     res = scs._is_relation_applicable('>', '1.5', ComparableVersion('1.4'))
     assert res is True
 
+    # Test gte operator
     res = scs._is_relation_applicable('>=', '1.4', ComparableVersion('1.4'))
     assert res is True
+    # Test lte operator
     res = scs._is_relation_applicable('<=', '1.4', ComparableVersion('1.4'))
     assert res is True
 
+    # Test eq operator
     res = scs._is_relation_applicable('=', '1.4', ComparableVersion('1.4'))
     assert res is True
+    # Test universal operator
     res = scs._is_relation_applicable('*', '1.9', ComparableVersion(''))
     assert res is True
 
@@ -701,6 +780,10 @@ def test_generate_snyk_report():
                 "pvt_pkg_vulnerability_count": 0
             },
             "npm": {
+                "premium_count": 0,
+                "pvt_pkg_vulnerability_count": 0
+            },
+            "golang": {
                 "premium_count": 0,
                 "pvt_pkg_vulnerability_count": 0
             }
@@ -754,18 +837,6 @@ def test_generate_snyk_report():
                         "premium": True,
                         "affected_version_count": 2,
                         "status": "success"
-                    },
-                    "SNYK-JS-DECOMPRESSTAR-559096": {
-                        "name": "decompress-tar",
-                        "premium": True,
-                        "affected_version_count": 14,
-                        "status": "success"
-                    },
-                    "SNYK-JS-DECOMPRESSTAR-559097": {
-                        "name": "decompress-tar",
-                        "premium": True,
-                        "affected_version_count": 1,
-                        "status": "success"
                     }
                 },
                 "delete": {
@@ -776,11 +847,38 @@ def test_generate_snyk_report():
                 },
                 "pvt_pkgs": {
                 }
+            },
+            "golang": {
+                "ingest": {
+                    "SNYK-Golang-DECOMPRESSTAR-559095": {
+                        "name": "gopkg1",
+                        "premium": True,
+                        "affected_version_count": 2,
+                        "affected_commit_hash_count": 20,
+                        "status": "success"
+                    },
+                    "SNYK-Golang-DECOMPRESSTAR-559096": {
+                        "name": "gopkg2",
+                        "premium": True,
+                        "affected_version_count": 3,
+                        "affected_commit_hash_count": 10,
+                        "status": "success"
+                    }
+                },
+                "delete": {
+                    "SNYK-Golang-DECOMPRESSTAR-559090": {
+                        "name": "gopkg4",
+                        "status": "success"
+                    }
+                },
+                "pvt_pkgs": {
+                }
             }
         }
     }
     scs._generate_snyk_report()
     stats = scs.SNYK_REPORT['stats']
+    # check report details for maven
     assert stats['maven']['successfully_ingested'] == 2
     assert stats['maven']['ingestion_accuracy'] == "66.67%"
     assert stats['maven']['successfully_deleted'] == 1
@@ -790,8 +888,16 @@ def test_generate_snyk_report():
     assert stats['maven']['premium_count'] == 2
     assert stats['maven']['pvt_pkg_vulnerability_count'] == 1
 
+    # check report details for python
     assert stats['pypi']['ingestion_accuracy'] == "NA"
     assert stats['pypi']['deletion_accuracy'] == "NA"
 
+    # check report details for npm
     assert stats['npm']['ingestion_accuracy'] == "100.0%"
     assert stats['npm']['deletion_accuracy'] == "100.0%"
+
+    # check report details for golang
+    assert stats['golang']['ingestion_accuracy'] == "100.0%"
+    assert stats['golang']['deletion_accuracy'] == "100.0%"
+    assert stats['golang']['commit_hash_affected'] == 30
+    assert stats['golang']['versions_affected'] == 5

--- a/tests/test_graph_snyk_cve_sync.py
+++ b/tests/test_graph_snyk_cve_sync.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 from datetime import datetime
 import os
 from f8a_version_comparator.comparable_version import ComparableVersion
-
-from graph_snyk_cve_sync import Helper, SnykCveSync
+from helper import Helper
+from graph_snyk_cve_sync import SnykCveSync
 
 data = {
     "ruby": [],
@@ -368,11 +368,11 @@ data = {
 }
 
 scs = SnykCveSync(data)
-h = Helper()
+helper = Helper()
 
 
 @patch("graph_snyk_cve_sync.SnykCveSync._parse_data_for_eco")
-@patch("graph_snyk_cve_sync.Helper.is_delta_mode_on")
+@patch("helper.Helper.is_delta_mode_on")
 def test_extract_data_from_feed(m1, m2):
     """Test extract_data_from_feed."""
     m1.return_value = False
@@ -444,7 +444,7 @@ def test_extract_data_from_feed(m1, m2):
     assert len(report_data['npm']['ingest']) == 3
 
 
-@patch("graph_snyk_cve_sync.Helper.is_delta_mode_on")
+@patch("helper.Helper.is_delta_mode_on")
 def test_extract_data_from_feed1(m1):
     """Test extract_data_from_feed in delta mode."""
     m1.return_value = True
@@ -478,7 +478,7 @@ def test_extract_data_from_feed1(m1):
 
 
 @responses.activate
-@patch('graph_snyk_cve_sync.Helper.is_dry_run')
+@patch('helper.Helper.is_dry_run')
 def test_insert_cves(mocker):
     """Test insert_cves."""
     mocker.return_value = True
@@ -526,7 +526,7 @@ def test_insert_cves(mocker):
 
 
 @responses.activate
-@patch('graph_snyk_cve_sync.Helper.is_dry_run')
+@patch('helper.Helper.is_dry_run')
 def test_delete_cves(mocker):
     """Test _delete_cves."""
     mocker.return_value = True
@@ -616,9 +616,9 @@ def test_delete_cves(mocker):
 @responses.activate
 @patch('graph_snyk_cve_sync.SnykCveSync._generate_snyk_report')
 @patch('graph_snyk_cve_sync.SnykCveSync._delete_cves')
-@patch('graph_snyk_cve_sync.Helper.store_json_content')
+@patch('helper.Helper.store_json_content')
 @patch('graph_snyk_cve_sync.SnykCveSync.disable_snyk_run')
-@patch('graph_snyk_cve_sync.Helper.read_data_from_s3')
+@patch('helper.Helper.read_data_from_s3')
 @patch('graph_snyk_cve_sync.SnykCveSync._extract_data_from_feed')
 @patch('graph_snyk_cve_sync.SnykCveSync._insert_cves')
 def test_run_snyk_sync(m1, m2, m3, m4, m5, m6, m7):
@@ -651,7 +651,7 @@ def test_disable_snyk_run():
     assert val is True
 
 
-@patch('graph_snyk_cve_sync.Helper.force_run_ingestion')
+@patch('helper.Helper.force_run_ingestion')
 def test_disable_snyk_run1(m1):
     """Test disable_snyk_run1."""
     m1.return_value = True
@@ -662,46 +662,46 @@ def test_disable_snyk_run1(m1):
 @patch.dict(os.environ, {'SNYK_DRY_RUN': 'true'})
 def test_is_dry_run():
     """Test is_dry_run."""
-    val = h.is_dry_run()
+    val = helper.is_dry_run()
     assert val is True
 
 
 @patch.dict(os.environ, {'SNYK_DRY_RUN': '0'})
 def test_is_dry_run1():
     """Test is_dry_run."""
-    val = h.is_dry_run()
+    val = helper.is_dry_run()
     assert val is False
 
 
 @patch.dict(os.environ, {'SNYK_INGESTION_FORCE_RUN': 'true'})
 def test_force_run_ingestion():
     """Test force_run_ingestion."""
-    val = h.force_run_ingestion()
+    val = helper.force_run_ingestion()
     assert val is True
 
 
 @patch.dict(os.environ, {'SNYK_INGESTION_FORCE_RUN': '0'})
 def test_force_run_ingestion1():
     """Test force_run_ingestion."""
-    val = h.force_run_ingestion()
+    val = helper.force_run_ingestion()
     assert val is False
 
 
 @patch.dict(os.environ, {'SNYK_DELTA_FEED_MODE': 'true'})
 def test_is_delta_mode_on():
     """Test is_delta_mode_on."""
-    val = h.is_delta_mode_on()
+    val = helper.is_delta_mode_on()
     assert val is True
 
 
 @patch.dict(os.environ, {'SNYK_DELTA_FEED_MODE': '0'})
 def test_is_delta_mode_on1():
     """Test is_delta_mode_on."""
-    val = h.is_delta_mode_on()
+    val = helper.is_delta_mode_on()
     assert val is False
 
 
-@patch('graph_snyk_cve_sync.Helper.is_delta_mode_on')
+@patch('helper.Helper.is_delta_mode_on')
 def test_parse_data_for_eco(m1):
     """Test parse_data_for_eco."""
     # Delta mode is on, so run for all ecosystems

--- a/tests/test_graph_snyk_cve_sync.py
+++ b/tests/test_graph_snyk_cve_sync.py
@@ -854,14 +854,12 @@ def test_generate_snyk_report():
                         "name": "gopkg1",
                         "premium": True,
                         "affected_version_count": 2,
-                        "affected_commit_hash_count": 20,
                         "status": "success"
                     },
                     "SNYK-Golang-DECOMPRESSTAR-559096": {
                         "name": "gopkg2",
                         "premium": True,
                         "affected_version_count": 3,
-                        "affected_commit_hash_count": 10,
                         "status": "success"
                     }
                 },
@@ -899,5 +897,5 @@ def test_generate_snyk_report():
     # check report details for golang
     assert stats['golang']['ingestion_accuracy'] == "100.0%"
     assert stats['golang']['deletion_accuracy'] == "100.0%"
-    assert stats['golang']['commit_hash_affected'] == 30
+    # assert stats['golang']['commit_hash_affected'] == 30
     assert stats['golang']['versions_affected'] == 5

--- a/tests/test_snyk_feed.py
+++ b/tests/test_snyk_feed.py
@@ -4,9 +4,11 @@ import pytest
 import os
 from unittest.mock import patch
 from datetime import datetime
+from helper import Helper
 
 from snyk_feed import SnykDataFetcher
 sdf = SnykDataFetcher()
+helper = Helper()
 
 
 class S3Obj:
@@ -28,7 +30,7 @@ def test_disable_snyk_run():
     assert val is True
 
 
-@patch('snyk_feed.Helper.force_run_ingestion')
+@patch('helper.Helper.force_run_ingestion')
 def test_disable_snyk_run1(m1):
     """Test disable_snyk_run1."""
     m1.return_value = True


### PR DESCRIPTION
A separate function was needed for golang as 
1. we are not using the util's pkg manager logic but rather using scraper
2. the flow/logic is a bit different from other eco
Embedding into a single function would cause a lot of if else logic which i wanted to avoid

Changes:
Golang support added
Webscraper method used to fetch details of golang pkg
Adding commit hash along with vuln versions