### PR TITLE
Lates Snyk feeds are not getting ingested.

### DIFF
--- a/graph_snyk_cve_sync.py
+++ b/graph_snyk_cve_sync.py
@@ -138,7 +138,7 @@ class SnykCveSync:
         self.today = self.utc_now.replace(hour=0, minute=0, second=0, microsecond=0)
         self.day = self.utc_now.weekday()
         delta_feed_offset = int(os.environ.get('SNYK_DELTA_FEED_OFFSET', '1'))
-        self.start_day = self.utc_now - timedelta(days=delta_feed_offset)
+        self.start_day = self.today - timedelta(days=delta_feed_offset)
         self.selective_eco_run = os.environ.get('SELECTIVE_ECOSYSTEM_SNYK_SYNC', 'none')
         if not data:
             self.snyk_data = self.helper.read_data_from_s3(self.utc_now.strftime('%d-%m-%Y'),


### PR DESCRIPTION
# Description

Snyk vulnerabilities are not getting picked up by the jobs for ingestion due to mismatch of time zones.